### PR TITLE
Update Endpoint to process all KAT rewards

### DIFF
--- a/src/app/quick-apys/page.tsx
+++ b/src/app/quick-apys/page.tsx
@@ -10,6 +10,12 @@ type VaultDisplay = {
   name: string
   netAPR: string
   katanaRewardsAPR: string
+  katanaAppRewardsAPR: string
+  fixedRateKatanaRewards: string
+  katanaBonusAPY: string
+  extrinsicYield: string
+  katanaNativeYield: string
+  totalAPR: string
 }
 
 export default function QuickAPYs(): React.ReactElement {
@@ -66,20 +72,41 @@ export default function QuickAPYs(): React.ReactElement {
         } else {
           console.log('No vaults found or data is not an object/array:', data)
         }
-        const displayVaults: VaultDisplay[] = vaultsArr.map((vault) => ({
-          key: vault.address,
-          name: vault.name,
-          netAPR:
+        const displayVaults: VaultDisplay[] = vaultsArr.map((vault) => {
+          const netAPR =
             vault.apr && typeof vault.apr.netAPR === 'number'
-              ? (vault.apr.netAPR * 100).toFixed(2)
-              : '-',
-          katanaRewardsAPR:
-            vault.apr &&
-            vault.apr.extra &&
-            typeof vault.apr.extra.katanaRewardsAPR === 'number'
-              ? (vault.apr.extra.katanaRewardsAPR * 100).toFixed(2)
-              : '-',
-        }))
+              ? vault.apr.netAPR
+              : 0
+          const katanaRewardsAPR = vault.apr?.extra?.katanaRewardsAPR || 0
+          const katanaAppRewardsAPR = vault.apr?.extra?.katanaAppRewardsAPR || 0
+          const fixedRateKatanaRewards =
+            vault.apr?.extra?.FixedRateKatanaRewards || 0
+          const katanaBonusAPY = vault.apr?.extra?.katanaBonusAPY || 0
+          const extrinsicYield = vault.apr?.extra?.extrinsicYield || 0
+          const katanaNativeYield = vault.apr?.extra?.katanaNativeYield || 0
+
+          // Calculate total APR as sum of all components
+          const totalAPR =
+            netAPR +
+            katanaAppRewardsAPR +
+            fixedRateKatanaRewards +
+            katanaBonusAPY +
+            extrinsicYield +
+            katanaNativeYield
+
+          return {
+            key: vault.address,
+            name: vault.name,
+            netAPR: (netAPR * 100).toFixed(2),
+            katanaRewardsAPR: (katanaRewardsAPR * 100).toFixed(2),
+            katanaAppRewardsAPR: (katanaAppRewardsAPR * 100).toFixed(2),
+            fixedRateKatanaRewards: (fixedRateKatanaRewards * 100).toFixed(2),
+            katanaBonusAPY: (katanaBonusAPY * 100).toFixed(2),
+            extrinsicYield: (extrinsicYield * 100).toFixed(2),
+            katanaNativeYield: (katanaNativeYield * 100).toFixed(2),
+            totalAPR: (totalAPR * 100).toFixed(2),
+          }
+        })
         console.log('Display vaults:', displayVaults)
         setVaults(displayVaults)
         setLoading(false)
@@ -93,10 +120,14 @@ export default function QuickAPYs(): React.ReactElement {
 
   return (
     <main className="flex flex-col items-center justify-center min-h-screen bg-gradient-to-b from-white to-gray-100 dark:from-[#18181b] dark:to-[#23232a] px-4 py-12">
-      <section className="w-full max-w-2xl bg-white/80 dark:bg-zinc-900/80 rounded-2xl shadow-xl p-8 flex flex-col items-center gap-8 border border-zinc-200 dark:border-zinc-800">
+      <section className="w-full max-w-6xl bg-white/80 dark:bg-zinc-900/80 rounded-2xl shadow-xl p-8 flex flex-col items-center gap-8 border border-zinc-200 dark:border-zinc-800">
         <h1 className="text-3xl font-bold text-center text-zinc-900 dark:text-white tracking-tight mb-2">
           Quick APYs
         </h1>
+        <p className="text-sm text-zinc-600 dark:text-zinc-400 text-center mb-4">
+          Comprehensive breakdown of all APR components including rewards,
+          bonuses, and yields
+        </p>
         <Link
           href="/"
           className="text-blue-600 dark:text-blue-400 underline mb-4"
@@ -108,36 +139,102 @@ export default function QuickAPYs(): React.ReactElement {
         ) : error ? (
           <p className="text-red-600 dark:text-red-400">{error}</p>
         ) : (
-          <table className="w-full text-left border-collapse">
-            <thead>
-              <tr>
-                <th className="px-4 py-2 border-b border-zinc-300 dark:border-zinc-700">
-                  Name
-                </th>
-                <th className="px-4 py-2 border-b border-zinc-300 dark:border-zinc-700 text-right">
-                  Net APY (%)
-                </th>
-                <th className="px-4 py-2 border-b border-zinc-300 dark:border-zinc-700 text-right">
-                  Katana Rewards APR (%)
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {vaults.map((vault) => (
-                <tr key={vault.key}>
-                  <td className="px-4 py-2 border-b border-zinc-200 dark:border-zinc-800">
-                    {vault.name}
-                  </td>
-                  <td className="px-4 py-2 border-b border-zinc-200 dark:border-zinc-800 text-right">
-                    {vault.netAPR}%
-                  </td>
-                  <td className="px-4 py-2 border-b border-zinc-200 dark:border-zinc-800 text-right">
-                    {vault.katanaRewardsAPR}%
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <>
+            <div className="overflow-x-auto">
+              <table className="w-full text-left border-collapse min-w-[800px]">
+                <thead>
+                  <tr>
+                    <th className="px-2 py-2 border-b border-zinc-300 dark:border-zinc-700 text-sm">
+                      Name
+                    </th>
+                    <th className="px-2 py-2 border-b border-zinc-300 dark:border-zinc-700 text-right text-sm">
+                      Net APR (%)
+                    </th>
+                    <th className="px-2 py-2 border-b border-zinc-300 dark:border-zinc-700 text-right text-sm">
+                      Katana App APR (%)
+                    </th>
+                    <th className="px-2 py-2 border-b border-zinc-300 dark:border-zinc-700 text-right text-sm">
+                      Fixed Rate APR (%)
+                    </th>
+                    <th className="px-2 py-2 border-b border-zinc-300 dark:border-zinc-700 text-right text-sm">
+                      Bonus APY (%)
+                    </th>
+                    <th className="px-2 py-2 border-b border-zinc-300 dark:border-zinc-700 text-right text-sm">
+                      Extrinsic Yield (%)
+                    </th>
+                    <th className="px-2 py-2 border-b border-zinc-300 dark:border-zinc-700 text-right text-sm">
+                      Native Yield (%)
+                    </th>
+                    <th className="px-2 py-2 border-b border-zinc-300 dark:border-zinc-700 text-right text-sm font-bold">
+                      Total APR (%)
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {vaults.map((vault) => (
+                    <tr key={vault.key}>
+                      <td className="px-2 py-2 border-b border-zinc-200 dark:border-zinc-800 text-sm">
+                        {vault.name}
+                      </td>
+                      <td className="px-2 py-2 border-b border-zinc-200 dark:border-zinc-800 text-right text-sm">
+                        {vault.netAPR}%
+                      </td>
+                      <td className="px-2 py-2 border-b border-zinc-200 dark:border-zinc-800 text-right text-sm">
+                        {vault.katanaAppRewardsAPR}%
+                      </td>
+                      <td className="px-2 py-2 border-b border-zinc-200 dark:border-zinc-800 text-right text-sm">
+                        {vault.fixedRateKatanaRewards}%
+                      </td>
+                      <td className="px-2 py-2 border-b border-zinc-200 dark:border-zinc-800 text-right text-sm">
+                        {vault.katanaBonusAPY}%
+                      </td>
+                      <td className="px-2 py-2 border-b border-zinc-200 dark:border-zinc-800 text-right text-sm">
+                        {vault.extrinsicYield}%
+                      </td>
+                      <td className="px-2 py-2 border-b border-zinc-200 dark:border-zinc-800 text-right text-sm">
+                        {vault.katanaNativeYield}%
+                      </td>
+                      <td className="px-2 py-2 border-b border-zinc-200 dark:border-zinc-800 text-right text-sm font-bold">
+                        {vault.totalAPR}%
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <details className="w-full mt-4">
+              <summary className="cursor-pointer text-sm text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-200">
+                Show Legacy Fields (for backwards compatibility)
+              </summary>
+              <div className="mt-4 overflow-x-auto">
+                <table className="w-full text-left border-collapse">
+                  <thead>
+                    <tr>
+                      <th className="px-4 py-2 border-b border-zinc-300 dark:border-zinc-700 text-sm">
+                        Name
+                      </th>
+                      <th className="px-4 py-2 border-b border-zinc-300 dark:border-zinc-700 text-right text-sm">
+                        Legacy Katana Rewards APR (%)
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {vaults.map((vault) => (
+                      <tr key={vault.key}>
+                        <td className="px-4 py-2 border-b border-zinc-200 dark:border-zinc-800 text-sm">
+                          {vault.name}
+                        </td>
+                        <td className="px-4 py-2 border-b border-zinc-200 dark:border-zinc-800 text-right text-sm">
+                          {vault.katanaRewardsAPR}%
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </details>
+          </>
         )}
       </section>
     </main>

--- a/src/app/services/aprCalcs/types.ts
+++ b/src/app/services/aprCalcs/types.ts
@@ -22,6 +22,7 @@ export interface RewardCalculatorResult {
 }
 
 export interface YearnRewardCalculatorResult {
+  vaultName: string
   vaultAddress: string
   poolType: string // e.g., 'morpho', 'steer'
   breakdown: TokenBreakdown
@@ -40,6 +41,7 @@ export interface Campaign {
 }
 
 export interface Opportunity {
+  name: string
   identifier: string
   campaigns?: Campaign[]
   apr?: number

--- a/src/app/services/aprCalcs/utils.ts
+++ b/src/app/services/aprCalcs/utils.ts
@@ -183,8 +183,6 @@ export const calculateYearnVaultRewardsAPR = (
         const isMatch =
           b.identifier &&
           b.identifier.toLowerCase() === String(campaignId).toLowerCase()
-        if (isMatch) {
-        }
         return isMatch
       })
 

--- a/src/app/services/aprCalcs/utils.ts
+++ b/src/app/services/aprCalcs/utils.ts
@@ -120,6 +120,7 @@ export const calculateStrategyAPR = (
  * If no opportunity or campaigns are found, returns a default result with 0 APR and null token details.
  * The final result combines token breakdowns by vault address.
  *
+ * @param vaultName - The name of the Yearn vault to calculate rewards for.
  * @param vaultAddress - The address of the Yearn vault to calculate rewards for.
  * @param opportunities - Array of available opportunities containing campaigns and APR records.
  * @param poolType - The type of pool (e.g., 'morpho') for which APR is being calculated.
@@ -128,6 +129,7 @@ export const calculateStrategyAPR = (
  *          or null if no opportunity is found for the vault address.
  */
 export const calculateYearnVaultRewardsAPR = (
+  vaultName: string,
   vaultAddress: string,
   opportunities: Opportunity[],
   poolType: string,
@@ -146,10 +148,11 @@ export const calculateYearnVaultRewardsAPR = (
   )
 
   if (!opportunity?.campaigns?.length) {
-    console.log(`No ${poolType} opportunity found for pool ${vaultAddress}`)
+    console.log(`No ${poolType} opportunity found for ${vaultName}`)
     // Return a result with 0 APR and null token details
     return [
       {
+        vaultName,
         vaultAddress,
         poolType,
         breakdown: {
@@ -165,39 +168,53 @@ export const calculateYearnVaultRewardsAPR = (
     ]
   }
 
-  // Find all campaigns with the specified rewardToken address
-  const targetCampaigns = opportunity.campaigns.filter((campaign: Campaign) => {
-    return isAddressEqual(
-      campaign.rewardToken.address as `0x${string}`,
-      targetRewardTokenAddress as `0x${string}`
-    )
-  })
-  console.log(
-    `Found ${targetCampaigns.length} campaigns for pool ${vaultAddress}`
-  )
-
+  // First check each campaign to see if its campaignId exists in aprRecord.breakdowns,
+  // then confirm the token matches
   const vaultAprValues: Array<{ apr: number; campaign: Campaign }> = []
   if (
-    targetCampaigns.length > 0 &&
     opportunity.aprRecord &&
-    Array.isArray(opportunity.aprRecord.breakdowns)
+    Array.isArray(opportunity.aprRecord.breakdowns) &&
+    opportunity.campaigns.length > 0
   ) {
-    for (const campaign of targetCampaigns) {
+    console.log(`\n${opportunity.name}\n------------`)
+    for (const campaign of opportunity.campaigns) {
       const campaignId = campaign.campaignId
-      const aprBreakdown = opportunity.aprRecord.breakdowns.find(
-        (b: any) =>
+      const aprBreakdown = opportunity.aprRecord.breakdowns.find((b: any) => {
+        const isMatch =
           b.identifier &&
           b.identifier.toLowerCase() === String(campaignId).toLowerCase()
-      )
+        if (isMatch) {
+        }
+        return isMatch
+      })
+
+      // If campaign has APR breakdown and token matches, include it
       if (aprBreakdown && typeof aprBreakdown.value === 'number') {
-        vaultAprValues.push({ apr: aprBreakdown.value, campaign })
+        console.log(
+          `Campaign ${campaignId} - Token: ${campaign.rewardToken.address} (${campaign.rewardToken.symbol}), Target: ${targetRewardTokenAddress}, APR: ${aprBreakdown.value}`
+        )
+
+        const tokenMatches = isAddressEqual(
+          campaign.rewardToken.address as `0x${string}`,
+          targetRewardTokenAddress as `0x${string}`
+        )
+        console.log(`Token matches: ${tokenMatches}`)
+
+        if (tokenMatches) {
+          console.log(`Adding campaign ${campaignId} to vaultAprValues`)
+          vaultAprValues.push({ apr: aprBreakdown.value, campaign })
+        }
       }
     }
   }
+  console.log(
+    `Found ${vaultAprValues.length} campaigns with APR data for pool ${vaultAddress}`
+  )
 
   // Return all APR breakdowns for each matching campaign
   const tokenBreakdowns: YearnRewardCalculatorResult[] = vaultAprValues.map(
     ({ apr, campaign }) => ({
+      vaultName,
       vaultAddress,
       poolType,
       breakdown: {
@@ -211,7 +228,6 @@ export const calculateYearnVaultRewardsAPR = (
       },
     })
   )
-  console.dir(tokenBreakdowns, { depth: null })
 
   return combineTokenBreakdowns(tokenBreakdowns, 'vaultAddress')
 }
@@ -248,5 +264,6 @@ function combineTokenBreakdowns<
       combined[key] = { ...item }
     }
   }
+  // console.dir(combined, { depth: null })
   return Object.values(combined)
 }

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -169,7 +169,9 @@ export class DataCacheService {
           'strategyAddress' in r && r.strategyAddress
             ? r.strategyAddress
             : 'vaultAddress' in r
-            ? (r as unknown as YearnRewardCalculatorResult).vaultAddress
+            ? isYearnRewardCalculatorResult(r)
+              ? r.vaultAddress
+              : undefined
             : undefined
         return isAddressEqual(
           addressToCheck as `0x${string}`,
@@ -287,4 +289,14 @@ export class DataCacheService {
 
     return newVault
   }
+}
+
+function isYearnRewardCalculatorResult(
+  r: RewardCalculatorResult & Record<'vaultAddress', unknown>
+): r is RewardCalculatorResult & YearnRewardCalculatorResult {
+  return (
+    typeof r.vaultAddress === 'string' &&
+    'breakdown' in r &&
+    r.poolType === 'yearn'
+  )
 }

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -169,9 +169,7 @@ export class DataCacheService {
           'strategyAddress' in r && r.strategyAddress
             ? r.strategyAddress
             : 'vaultAddress' in r
-            ? isYearnRewardCalculatorResult(r)
-              ? r.vaultAddress
-              : undefined
+            ? (r as unknown as YearnRewardCalculatorResult).vaultAddress
             : undefined
         return isAddressEqual(
           addressToCheck as `0x${string}`,
@@ -289,14 +287,4 @@ export class DataCacheService {
 
     return newVault
   }
-}
-
-function isYearnRewardCalculatorResult(
-  r: RewardCalculatorResult & Record<'vaultAddress', unknown>
-): r is RewardCalculatorResult & YearnRewardCalculatorResult {
-  return (
-    typeof r.vaultAddress === 'string' &&
-    'breakdown' in r &&
-    r.poolType === 'yearn'
-  )
 }

--- a/src/app/services/externalApis/merklApi.ts
+++ b/src/app/services/externalApis/merklApi.ts
@@ -59,6 +59,16 @@ export class MerklApiService {
     }
   }
 
+  /**
+   * Fetches Yearn opportunities from the Merkl API.
+   *
+   * Sends a GET request to the `/v4/opportunities` endpoint with parameters for Yearn,
+   * the configured chain ID, and campaign information. Handles responses that may be
+   * either an array of opportunities or an object containing an `opportunities` array.
+   *
+   * @returns {Promise<MerklOpportunity[]>} A promise that resolves to an array of Yearn opportunities.
+   * If an error occurs during the fetch, an empty array is returned.
+   */
   async getYearnOpportunities(): Promise<MerklOpportunity[]> {
     try {
       const url: string = `${this.apiUrl}/v4/opportunities`
@@ -83,6 +93,20 @@ export class MerklApiService {
       return []
     }
   }
+
+  /**
+   * Fetches ERC20 Log Processor opportunities from the Merkl API.
+   *
+   * Sends a GET request to the `/v4/opportunities/campaigns` endpoint with the specified parameters:
+   * - `status`: 'LIVE'
+   * - `chainId`: from configuration
+   * - `type`: 'ERC20LOGPROCESSOR'
+   *
+   * Handles responses that may either be a direct array of `MerklOpportunity` objects or an object containing an `opportunities` array.
+   * In case of an error, logs the error and returns an empty array.
+   *
+   * @returns {Promise<MerklOpportunity[]>} A promise that resolves to an array of `MerklOpportunity` objects.
+   */
   async getErc20LogProcessorOpportunities(): Promise<MerklOpportunity[]> {
     try {
       const url: string = `${this.apiUrl}/v4/opportunities/campaigns`
@@ -90,6 +114,41 @@ export class MerklApiService {
         status: 'LIVE',
         chainId: config.katanaChainId,
         type: 'ERC20LOGPROCESSOR',
+      }
+
+      const response = await axios.get<
+        MerklOpportunity[] | { opportunities: MerklOpportunity[] }
+      >(url, { params })
+
+      // The response is an array directly
+      const opportunities: MerklOpportunity[] = Array.isArray(response.data)
+        ? response.data
+        : response.data.opportunities || []
+
+      return opportunities
+    } catch (error) {
+      console.error('Error fetching ERC20 Log Processor opportunities:', error)
+      return []
+    }
+  }
+
+  /**
+   * Fetches ERC20 fixed APR opportunities from the Merkl API.
+   *
+   * This method sends a GET request to the `/v4/opportunities/campaigns` endpoint,
+   * filtering for opportunities with status 'LIVE', the configured chain ID, and type 'ERC20_FIX_APR'.
+   * The response may be either an array of `MerklOpportunity` objects or an object containing an `opportunities` array.
+   * In case of an error, an empty array is returned and the error is logged to the console.
+   *
+   * @returns {Promise<MerklOpportunity[]>} A promise that resolves to an array of `MerklOpportunity` objects.
+   */
+  async getErc20FixAprOpportunities(): Promise<MerklOpportunity[]> {
+    try {
+      const url: string = `${this.apiUrl}/v4/opportunities/campaigns`
+      const params = {
+        status: 'LIVE',
+        chainId: config.katanaChainId,
+        type: 'ERC20_FIX_APR',
       }
 
       const response = await axios.get<

--- a/src/app/types/yearn.ts
+++ b/src/app/types/yearn.ts
@@ -26,6 +26,7 @@ export interface YearnStrategy {
 }
 
 export interface YearnVaultExtra {
+  katanaRewardsAPR?: number // legacy field
   katanaAppRewardsAPR?: number
   FixedRateKatanaRewards?: number
   katanaBonusAPY?: number
@@ -77,7 +78,7 @@ export interface YearnVault {
   address: string
   symbol: string
   name: string
-  chainId: number
+  chainID: number
   strategies: YearnStrategy[]
   apr?: YearnVaultAPY
   tvl?: YearnVaultTVL

--- a/src/app/types/yearn.ts
+++ b/src/app/types/yearn.ts
@@ -1,81 +1,85 @@
 export interface YearnStrategyDetails {
-  totalDebt: string;
-  totalGain: string;
-  totalLoss: string;
-  lastReport: number;
-  performanceFee?: number;
-  debtRatio?: number;
+  totalDebt: string
+  totalGain: string
+  totalLoss: string
+  lastReport: number
+  performanceFee?: number
+  debtRatio?: number
 }
 
 export interface YearnRewardToken {
-  address: string;
-  symbol: string;
-  decimals: number;
-  assumedFDV?: number;
+  address: string
+  symbol: string
+  decimals: number
+  assumedFDV?: number
 }
 
 export interface YearnStrategy {
-  address: string;
-  name: string;
-  status?: string;
-  netAPR?: number;
-  strategyRewardsAPR?: number;
-  rewardToken?: YearnRewardToken;
-  underlyingContract?: string;
-  details?: YearnStrategyDetails;
+  address: string
+  name: string
+  status?: string
+  netAPR?: number
+  strategyRewardsAPR?: number
+  rewardToken?: YearnRewardToken
+  underlyingContract?: string
+  details?: YearnStrategyDetails
 }
 
 export interface YearnVaultExtra {
-  katanaRewardsAPR?: number;
+  katanaAppRewardsAPR?: number
+  FixedRateKatanaRewards?: number
+  katanaBonusAPY?: number
+  extrinsicYield?: number
+  katanaNativeYield?: number
 }
 
 export interface YearnVaultPricePerShare {
-  today: number;
-  weekAgo: number;
-  monthAgo: number;
+  today: number
+  weekAgo: number
+  monthAgo: number
 }
 
 export interface YearnVaultPoints {
-  weekAgo: number;
-  monthAgo: number;
-  inception: number;
+  weekAgo: number
+  monthAgo: number
+  inception: number
 }
 
 export interface YearnVaultFees {
-  performance: number;
-  management: number;
+  performance: number
+  management: number
 }
 
 export interface YearnVaultAPY {
-  type: string;
-  netAPR: number;
-  fees?: YearnVaultFees;
-  points?: YearnVaultPoints;
-  pricePerShare?: YearnVaultPricePerShare;
-  extra?: YearnVaultExtra;
+  type?: string
+  netAPR?: number
+  fees?: YearnVaultFees
+  points?: YearnVaultPoints
+  pricePerShare?: YearnVaultPricePerShare
+  extra?: YearnVaultExtra
 }
 
 export interface YearnVaultTVL {
-  totalAssets: string;
-  tvl: number;
-  price: number;
+  totalAssets: string
+  tvl: number
+  price: number
 }
 
 export interface YearnVaultToken {
-  address: string;
-  name: string;
-  symbol: string;
-  decimals: number;
-  description?: string;
+  address: string
+  name: string
+  symbol: string
+  decimals: number
+  description?: string
 }
 
 export interface YearnVault {
-  address: string;
-  symbol: string;
-  name: string;
-  chainId: number;
-  strategies: YearnStrategy[];
-  apr?: YearnVaultAPY;
-  tvl?: YearnVaultTVL;
-  token?: YearnVaultToken;
+  address: string
+  symbol: string
+  name: string
+  chainId: number
+  strategies: YearnStrategy[]
+  apr?: YearnVaultAPY
+  tvl?: YearnVaultTVL
+  token?: YearnVaultToken
 }


### PR DESCRIPTION
API now returns additional fields in the apr.extra section of the returned data for each vault. Added fields are:
`katanaAppRewardsAPR`
`FixedRateKatanaRewards `
`katanaBonusAPY`
 `extrinsicYield`
`katanaNativeYield`

`KatanaRewardsAPR` is maintained for backward compatibility.

Changes:
- Added function to fetch fixed rate rewards to vaults from Merkl API
- Add hardcoded values for additional Katana rewards and push through to endpoint.
- Improve filtering from campaigns
- Add more function documentation