### PR TITLE
feat: STEER points calculator and data cache integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Katana APR Service
 
-This is a Next.js app that provides APR data for Yearn vaults on Katana via API endpoints. It is designed for serverless deployment (e.g., Vercel).
+This is a Next.js app that provides APR and points data for Yearn vaults on Katana via API endpoints. It is designed for serverless deployment (e.g., Vercel).
 
 ## Getting Started
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "bunx vitest -c vitest.config.ts",
+    "test:run": "bunx vitest run -c vitest.config.ts"
   },
   "dependencies": {
     "@types/lodash": "^4.17.20",
@@ -29,6 +31,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.5",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^2.0.0"
   }
 }

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -4,6 +4,7 @@ import { config } from '../config/index'
 import type { YearnVault } from '../types/index'
 import { YearnApiService } from './externalApis/yearnApi'
 import { YearnAprCalculator } from './aprCalcs/yearnAprCalculator'
+import { SteerPointsCalculator } from './pointsCalcs/steerPointsCalculator'
 import {
   type RewardCalculatorResult,
   TokenBreakdown,
@@ -78,10 +79,12 @@ const FDV = 1_000_000_000
 export class DataCacheService {
   private yearnApi: YearnApiService
   private yearnAprCalculator: YearnAprCalculator
+  private steerPointsCalculator: SteerPointsCalculator
 
   constructor() {
     this.yearnApi = new YearnApiService()
     this.yearnAprCalculator = new YearnAprCalculator()
+    this.steerPointsCalculator = new SteerPointsCalculator()
   }
 
   async generateVaultAPRData(): Promise<APRDataCache> {
@@ -270,6 +273,7 @@ export class DataCacheService {
         katanaBonusAPY: vaultKatanaBonusAPY,
         extrinsicYield,
         katanaNativeYield,
+        steerPointsPerDollar: this.steerPointsCalculator.calculateForVault(vault),
       },
     }
 

--- a/src/app/services/pointsCalcs/steerPointsCalculator.test.ts
+++ b/src/app/services/pointsCalcs/steerPointsCalculator.test.ts
@@ -2,7 +2,16 @@ import { describe, it, expect } from 'vitest'
 import { SteerPointsCalculator, STEER_REWARD_RATES } from './steerPointsCalculator'
 import type { YearnVault } from '../../types'
 
-function makeVault(strategies: Array<Partial<YearnVault['strategies'][number]>>): YearnVault {
+type MinimalStrategyInput = {
+  name?: string
+  address?: string
+  details?: {
+    totalDebt?: string | number
+    debtRatio?: number
+  }
+}
+
+function makeVault(strategies: Array<MinimalStrategyInput>): YearnVault {
   // Build a minimal YearnVault with only fields used by the calculator
   return {
     address: '0xvault',
@@ -60,4 +69,3 @@ describe('SteerPointsCalculator', () => {
     expect(calc.calculateForVault(vault)).toBe(0)
   })
 })
-

--- a/src/app/services/pointsCalcs/steerPointsCalculator.test.ts
+++ b/src/app/services/pointsCalcs/steerPointsCalculator.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { SteerPointsCalculator, STEER_REWARD_RATES } from './steerPointsCalculator'
+import type { YearnVault } from '../../types'
+
+function makeVault(strategies: Array<Partial<YearnVault['strategies'][number]>>): YearnVault {
+  // Build a minimal YearnVault with only fields used by the calculator
+  return {
+    address: '0xvault',
+    symbol: 'VAULT',
+    name: 'Test Vault',
+    chainID: 1,
+    strategies: strategies.map((s, i) => ({
+      address: (s.address as string) ?? (`0xstrat${i}` as string),
+      name: (s.name as string) ?? `Strategy ${i}`,
+      details: {
+        totalDebt: String(s.details?.totalDebt ?? '0'),
+        totalGain: '0',
+        totalLoss: '0',
+        lastReport: 0,
+        debtRatio: s.details?.debtRatio ?? 0,
+      },
+    })),
+  }
+}
+
+describe('SteerPointsCalculator', () => {
+  const calc = new SteerPointsCalculator()
+
+  it('returns 0 when no strategies match', () => {
+    const vault = makeVault([
+      { name: 'Unrelated Strategy', details: { totalDebt: '100', debtRatio: 1000 } },
+    ])
+    expect(calc.calculateForVault(vault)).toBe(0)
+  })
+
+  it('awards points for matching strategy with positive rate and debt', () => {
+    // Using a key known to have rate 2 in STEER_REWARD_RATES
+    const key = Object.keys(STEER_REWARD_RATES).find((k) => STEER_REWARD_RATES[k] === 2)!
+    const vault = makeVault([
+      { name: `My ${key} Position`, details: { totalDebt: '1000', debtRatio: 5000 } }, // 50%
+    ])
+    // Expected: 2 * 0.5 = 1.0
+    expect(calc.calculateForVault(vault)).toBeCloseTo(1.0, 6)
+  })
+
+  it('sums across multiple eligible strategies and clamps debtRatio to [0,1]', () => {
+    const vault = makeVault([
+      { name: 'weETH-vbETH LP', details: { totalDebt: '1', debtRatio: 12000 } }, // 2 * 1.0 = 2
+      { name: 'AUSD-vbUSDC Pool', details: { totalDebt: '500', debtRatio: 2500 } }, // 1 * 0.25 = 0.25
+      { name: 'vbWBTC-LBTC', details: { totalDebt: '100', debtRatio: 10000 } }, // rate 0 => 0
+      { name: 'vbUSDC-vbUSDT', details: { totalDebt: '0', debtRatio: 10000 } }, // totalDebt 0 => ignored
+    ])
+    expect(calc.calculateForVault(vault)).toBeCloseTo(2.25, 6)
+  })
+
+  it('ignores strategies with zero totalDebt', () => {
+    const vault = makeVault([
+      { name: 'weETH-vbETH LP', details: { totalDebt: '0', debtRatio: 10000 } },
+    ])
+    expect(calc.calculateForVault(vault)).toBe(0)
+  })
+})
+

--- a/src/app/services/pointsCalcs/steerPointsCalculator.ts
+++ b/src/app/services/pointsCalcs/steerPointsCalculator.ts
@@ -21,10 +21,12 @@ export class SteerPointsCalculator {
 
     // Precompute lowercased keys with positive rates and a mapping
     const positiveRateKeys = Object.entries(STEER_REWARD_RATES)
-      .filter(([_, rate]) => rate > 0)
-      .map(([key, _]) => key.toLowerCase())
-    const positiveRateMap: Record<string, number> = Object.entries(STEER_REWARD_RATES)
-      .filter(([_, rate]) => rate > 0)
+      .filter(([, rate]) => rate > 0)
+      .map(([key]) => key.toLowerCase())
+    const positiveRateMap: Record<string, number> = Object.entries(
+      STEER_REWARD_RATES
+    )
+      .filter(([, rate]) => rate > 0)
       .reduce((acc, [key, rate]) => {
         acc[key.toLowerCase()] = rate
         return acc
@@ -50,4 +52,3 @@ export class SteerPointsCalculator {
     return total
   }
 }
-

--- a/src/app/services/pointsCalcs/steerPointsCalculator.ts
+++ b/src/app/services/pointsCalcs/steerPointsCalculator.ts
@@ -1,0 +1,45 @@
+import type { YearnVault } from '../../types'
+
+// Mirrors Yearn X app configuration
+// Key match is case-insensitive against strategy.name
+export const STEER_REWARD_RATES: Record<string, number> = {
+  'weETH-vbETH': 2,
+  'AUSD-vbUSDC': 1,
+  'vbUSDC-vbUSDT': 1,
+  'vbWBTC-LBTC': 0,
+  'vbWBTC-BTCK': 0,
+}
+
+export class SteerPointsCalculator {
+  /**
+   * Calculate STEER reward points per dollar invested for a given vault.
+   * Sums rate * (debtRatio/10000) for strategies whose names include a
+   * configured positive-rate key and have totalDebt > 0.
+   */
+  calculateForVault(vault: YearnVault): number {
+    const strategies = vault.strategies ?? []
+
+    const eligible = strategies.filter((s) => {
+      const name = (s?.name ?? '').toLowerCase()
+      const hasMatch = Object.entries(STEER_REWARD_RATES).some(([key, rate]) => {
+        return rate > 0 && name.includes(key.toLowerCase())
+      })
+      const totalDebt = Number(s?.details?.totalDebt ?? 0)
+      return hasMatch && totalDebt > 0
+    })
+
+    const total = eligible.reduce((sum, s) => {
+      const name = (s?.name ?? '').toLowerCase()
+      const match = Object.entries(STEER_REWARD_RATES).find(
+        ([key, rate]) => rate > 0 && name.includes(key.toLowerCase())
+      )
+      const rate = match ? Number(match[1]) : 0
+      const raw = Number(s?.details?.debtRatio ?? 0) // 10000 = 100%
+      const debtRatio = Math.min(Math.max(raw / 10000, 0), 1)
+      return sum + rate * debtRatio
+    }, 0)
+
+    return total
+  }
+}
+

--- a/src/app/types/yearn.ts
+++ b/src/app/types/yearn.ts
@@ -32,6 +32,8 @@ export interface YearnVaultExtra {
   katanaBonusAPY?: number
   extrinsicYield?: number
   katanaNativeYield?: number
+  // Points per dollar invested from STEER allocations
+  steerPointsPerDollar?: number
 }
 
 export interface YearnVaultPricePerShare {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,10 @@
   },
   "suppressImplicitAnyIndexErrors": true,
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "vitest.config.ts"
+  ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    globals: true,
+    // Avoid worker threads which can hang under some Bun setups
+    pool: 'forks',
+    maxThreads: 1,
+    minThreads: 1,
+    watch: false,
+  },
+  // Avoid loading project PostCSS/Tailwind config during isolated unit tests
+  css: {
+    postcss: {
+      plugins: [],
+    },
+  },
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,8 +7,6 @@ export default defineConfig({
     globals: true,
     // Avoid worker threads which can hang under some Bun setups
     pool: 'forks',
-    maxThreads: 1,
-    minThreads: 1,
     watch: false,
   },
   // Avoid loading project PostCSS/Tailwind config during isolated unit tests


### PR DESCRIPTION
Summary
- Adds a STEER points calculator that computes points-per-dollar for Katana vaults based on strategy allocations, mirroring Yearn X logic.

Details
- New file: src/app/services/pointsCalcs/steerPointsCalculator.ts
  - Uses STEER_REWARD_RATES mapping and strategy debt ratios.
  - Points per dollar = sum over eligible strategies of (rate * debtRatio/10000).
- Integration: src/app/services/dataCache.ts
  - Injects calculator and exposes value at apr.extra.steerPointsPerDollar per vault.
- Types: src/app/types/yearn.ts
  - Adds optional apr.extra.steerPointsPerDollar.

Why
- Aligns service-side data with the front-end points display so API consumers can access points directly.

Validation
- Lint: next lint (existing unrelated warning in aprCalcs/types.ts persists).
- Build: next build successful locally.

Notes
- STEER_REWARD_RATES mirrored from Yearn X constants.