### PR TITLE
chore: update Bonus APY

### DIFF
--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -32,11 +32,11 @@ const katanaBonusAPY: Record<
   'yvvbETH' | 'yvvbUSDC' | 'yvvbUSDT' | 'AUSD' | 'yvvbWBTC' | 'yvvbUSDS',
   number
 > = {
-  yvvbETH: 0.02,
-  yvvbUSDC: 0.08,
-  yvvbUSDT: 0.08,
-  AUSD: 0.08,
-  yvvbWBTC: 0.02,
+  yvvbETH: 0.016,
+  yvvbUSDC: 0.068,
+  yvvbUSDT: 0.068,
+  AUSD: 0.068,
+  yvvbWBTC: 0.016,
   yvvbUSDS: 0.0,
 }
 
@@ -273,7 +273,8 @@ export class DataCacheService {
         katanaBonusAPY: vaultKatanaBonusAPY,
         extrinsicYield,
         katanaNativeYield,
-        steerPointsPerDollar: this.steerPointsCalculator.calculateForVault(vault),
+        steerPointsPerDollar:
+          this.steerPointsCalculator.calculateForVault(vault),
       },
     }
 


### PR DESCRIPTION
Update Bonus APY values per Katana tranching values

<img width="1280" height="355" alt="image" src="https://github.com/user-attachments/assets/834a540e-f8f6-4fc6-903b-666170f55e42" />

Katana reached 300M TVL, so the rates dropped to 1.6 and 6.8 