### PR TITLE
chore: update rewards per katana

### DIFF
--- a/src/app/quick-apys/page.tsx
+++ b/src/app/quick-apys/page.tsx
@@ -13,7 +13,6 @@ type VaultDisplay = {
   katanaAppRewardsAPR: string
   fixedRateKatanaRewards: string
   katanaBonusAPY: string
-  extrinsicYield: string
   katanaNativeYield: string
   totalAPR: string
 }
@@ -82,7 +81,6 @@ export default function QuickAPYs(): React.ReactElement {
           const fixedRateKatanaRewards =
             vault.apr?.extra?.FixedRateKatanaRewards || 0
           const katanaBonusAPY = vault.apr?.extra?.katanaBonusAPY || 0
-          const extrinsicYield = vault.apr?.extra?.extrinsicYield || 0
           const katanaNativeYield = vault.apr?.extra?.katanaNativeYield || 0
 
           // Calculate total APR as sum of all components
@@ -91,7 +89,6 @@ export default function QuickAPYs(): React.ReactElement {
             katanaAppRewardsAPR +
             fixedRateKatanaRewards +
             katanaBonusAPY +
-            extrinsicYield +
             katanaNativeYield
 
           return {
@@ -102,7 +99,6 @@ export default function QuickAPYs(): React.ReactElement {
             katanaAppRewardsAPR: (katanaAppRewardsAPR * 100).toFixed(2),
             fixedRateKatanaRewards: (fixedRateKatanaRewards * 100).toFixed(2),
             katanaBonusAPY: (katanaBonusAPY * 100).toFixed(2),
-            extrinsicYield: (extrinsicYield * 100).toFixed(2),
             katanaNativeYield: (katanaNativeYield * 100).toFixed(2),
             totalAPR: (totalAPR * 100).toFixed(2),
           }
@@ -187,9 +183,6 @@ export default function QuickAPYs(): React.ReactElement {
                       </td>
                       <td className="px-2 py-2 border-b border-zinc-200 dark:border-zinc-800 text-right text-sm">
                         {vault.katanaBonusAPY}%
-                      </td>
-                      <td className="px-2 py-2 border-b border-zinc-200 dark:border-zinc-800 text-right text-sm">
-                        {vault.extrinsicYield}%
                       </td>
                       <td className="px-2 py-2 border-b border-zinc-200 dark:border-zinc-800 text-right text-sm">
                         {vault.katanaNativeYield}%

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -40,34 +40,6 @@ const katanaBonusAPY: Record<
   yvvbUSDS: 0.0,
 }
 
-/**
- * This is a guaranteed rate on the underlying APYs by the katana team for the vaults.
- * The mainnet or tbill yields are extrinsic yields that are earned elsewhere.
- * the katana yield is the netAPR value earned by the vault and if it does not hit the below
- * thresholds, then the diference will be made up with KAT tokens valued at 1B FDV.
- *
- * The aggregateVaultResults() function will automatically calculate and display the larger
- * or the katana yield or the netAPR value.
- */
-const vaultNativeRewards: Record<
-  | 'yvvbETH'
-  | 'yvvbUSDC'
-  | 'yvvbUSDT'
-  | 'AUSD'
-  | 'yvvbWBTC'
-  | 'yvvbUSDS'
-  | 'yvwstETH',
-  Record<string, number>
-> = {
-  yvvbETH: { 'Ethereum yield': 0.013, 'Katana yield': 0.027 },
-  yvvbUSDC: { 'Ethereum yield': 0.021, 'Katana yield': 0.03 },
-  yvvbUSDT: { 'Ethereum yield': 0.017, 'Katana yield': 0.03 },
-  AUSD: { 'T-bill yield': 0.035, 'Katana yield': 0.0 },
-  yvvbWBTC: { 'Ethereum yield': 0.0001, 'Katana yield': 0.008 },
-  yvvbUSDS: { 'Ethereum yield': 0.0, 'Katana yield': 0.0 },
-  yvwstETH: { 'Ethereum yield': 0.0, 'Katana yield': 0.0 },
-}
-
 const HARDCODED_FIXED_RATE_APR: Record<
   | 'yvvbETH'
   | 'yvvbUSDC'
@@ -256,24 +228,8 @@ export class DataCacheService {
     const vaultKatanaBonusAPY =
       katanaBonusAPY[vault.symbol as keyof typeof katanaBonusAPY] || 0
 
-    // Calculate extrinsicYield and katanaNativeYield
-    const nativeRewards =
-      vaultNativeRewards[vault.symbol as keyof typeof vaultNativeRewards]
-    let extrinsicYield = 0
-    let katanaNativeYield = 0
-
-    if (nativeRewards) {
-      const rewardValues = Object.values(nativeRewards)
-      const firstField = rewardValues[0] || 0
-      const secondField = rewardValues[1] || 0
-      const netAPR = vault.apr?.netAPR || 0
-
-      // extrinsicYield is always the first value
-      extrinsicYield = firstField
-
-      // katanaNativeYield is the greater of the second field or netAPR
-      katanaNativeYield = Math.max(secondField, netAPR)
-    }
+    // katanaNativeYield is the greater of the second field or netAPR
+    const katanaNativeYield = vault.apr?.netAPR || 0
 
     const apr = {
       ...vault.apr,
@@ -283,7 +239,6 @@ export class DataCacheService {
         katanaAppRewardsAPR: yearnVaultRewards || 0, // new field
         FixedRateKatanaRewards: fixedRateFromHardcoded || 0,
         katanaBonusAPY: vaultKatanaBonusAPY,
-        extrinsicYield,
         katanaNativeYield,
         steerPointsPerDollar:
           this.steerPointsCalculator.calculateForVault(vault),

--- a/src/app/types/yearn.ts
+++ b/src/app/types/yearn.ts
@@ -30,7 +30,6 @@ export interface YearnVaultExtra {
   katanaAppRewardsAPR?: number
   FixedRateKatanaRewards?: number
   katanaBonusAPY?: number
-  extrinsicYield?: number
   katanaNativeYield?: number
   // Points per dollar invested from STEER allocations
   steerPointsPerDollar?: number


### PR DESCRIPTION
see https://github.com/yearn/yearn.fi/pull/860 in main yearn.fi repo.

Request from Katana team:
2 changes to the APY breakdown notes worth updating before tomorrow to avoid user confusion:

- Native APY: We’ve removed the L1 APY. Previously this was double-counted since VB yield was donated directly at the Yearn vault level and already reflected in the Yearn APY’s PPS increase. In v1, Native APY now simply reflects the 30-day Yearn APY.
- We’ve also removed the KAT top-up disclaimer. Take a look at the v1 app for reference.
- Base rewards: no change
- App rewards: no change
- Early deposit bonus: no change (this ended back on Sept 1, but we’ve left it displayed for now)

To test: run `npm dev` and confirm extrinsic yield is removed 