### PR TITLE
add excluded campaigns filter and remove jumper campaigns

### DIFF
--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -193,9 +193,6 @@ export class DataCacheService {
       }
     })
 
-    /**
-     * temp turned off while rewards are messed up
-     *  
     // Find vault-level APR results (where vaultAddress matches vault.address)
     const vaultLevelResults = results.filter(
       (r) => 'vaultAddress' in r && r.vaultAddress === vault.address,
@@ -210,7 +207,6 @@ export class DataCacheService {
         sum + (result.breakdown?.apr ? result.breakdown.apr / 100 : 0),
       0,
     )
-    */
 
     // use this when fixed rate pools are live
     // const fixedRateResults = vaultLevelResults.filter(
@@ -239,10 +235,8 @@ export class DataCacheService {
       ...vault.apr,
       extra: {
         ...(vault.apr?.extra || {}),
-        // katanaRewardsAPR: yearnVaultRewards || 0, // legacy field
-        // katanaAppRewardsAPR: yearnVaultRewards || 0, // new field
-        katanaRewardsAPR: 0, // temp override while rewards are messed up and we fix
-        katanaAppRewardsAPR: 0, // temp override while rewards are messed up and we fix
+        katanaRewardsAPR: yearnVaultRewards || 0, // legacy field
+        katanaAppRewardsAPR: yearnVaultRewards || 0, // new field
         FixedRateKatanaRewards: fixedRateFromHardcoded || 0,
         katanaBonusAPY: vaultKatanaBonusAPY,
         katanaNativeYield,

--- a/src/app/services/externalApis/merklApi.ts
+++ b/src/app/services/externalApis/merklApi.ts
@@ -2,11 +2,40 @@ import axios from 'axios'
 import { config } from '../../config'
 import type { MerklOpportunity } from '../../types'
 
+const EXCLUDED_CAMPAIGN_IDS = new Set([
+  '0x487022e5f413f60e3e6aa251712f9c2d6601f01d14b565e779a61b68c173bd6c',
+  '0xc5a22d022154d5c64ff14b2f4071f134eb83cf159f9f846ad0ba0908a755e86d',
+])
+
 export class MerklApiService {
   private apiUrl: string
 
   constructor() {
     this.apiUrl = config.merklApiUrl
+  }
+
+  private filterCampaigns(
+    opportunities: MerklOpportunity[],
+  ): MerklOpportunity[] {
+    return opportunities.map((opportunity) => {
+      if (!opportunity.campaigns?.length) {
+        return opportunity
+      }
+
+      const filteredCampaigns = opportunity.campaigns.filter((campaign) => {
+        const campaignId = campaign.campaignId?.toLowerCase()
+        return !campaignId || !EXCLUDED_CAMPAIGN_IDS.has(campaignId)
+      })
+
+      if (filteredCampaigns.length === opportunity.campaigns.length) {
+        return opportunity
+      }
+
+      return {
+        ...opportunity,
+        campaigns: filteredCampaigns,
+      }
+    })
   }
 
   async getSushiOpportunities(): Promise<MerklOpportunity[]> {
@@ -27,7 +56,7 @@ export class MerklApiService {
         ? response.data
         : response.data.opportunities || []
 
-      return opportunities
+      return this.filterCampaigns(opportunities)
     } catch (error) {
       console.error('Error fetching Sushi opportunities:', error)
       return []
@@ -52,7 +81,7 @@ export class MerklApiService {
         ? response.data
         : response.data.opportunities || []
 
-      return opportunities
+      return this.filterCampaigns(opportunities)
     } catch (error) {
       console.error('Error fetching Morpho opportunities:', error)
       return []
@@ -87,7 +116,7 @@ export class MerklApiService {
         ? response.data
         : response.data.opportunities || []
 
-      return opportunities
+      return this.filterCampaigns(opportunities)
     } catch (error) {
       console.error('Error fetching Yearn opportunities:', error)
       return []
@@ -125,7 +154,7 @@ export class MerklApiService {
         ? response.data
         : response.data.opportunities || []
 
-      return opportunities
+      return this.filterCampaigns(opportunities)
     } catch (error) {
       console.error('Error fetching ERC20 Log Processor opportunities:', error)
       return []
@@ -160,7 +189,7 @@ export class MerklApiService {
         ? response.data
         : response.data.opportunities || []
 
-      return opportunities
+      return this.filterCampaigns(opportunities)
     } catch (error) {
       console.error('Error fetching ERC20 Log Processor opportunities:', error)
       return []

--- a/src/app/types/merkl.ts
+++ b/src/app/types/merkl.ts
@@ -6,6 +6,7 @@ export interface MerklRewardToken {
 }
 
 export interface MerklCampaign {
+  campaignId?: string
   amount: string
   rewardToken: MerklRewardToken
   startTimestamp: number


### PR DESCRIPTION
Jumper campaigns should not be included in app rewards as they are only available through their interface.

this PR turns APP rewards back on, but filters out the jumper campaigns:
```
  '0x487022e5f413f60e3e6aa251712f9c2d6601f01d14b565e779a61b68c173bd6c',
  '0xc5a22d022154d5c64ff14b2f4071f134eb83cf159f9f846ad0ba0908a755e86d',
  ```