### PR TITLE
Fix bad fallback and improve debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+.codex

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "katana-apr-service",

--- a/docs/vault-apr-debug.md
+++ b/docs/vault-apr-debug.md
@@ -50,6 +50,7 @@ bun run test:vault-debug:live -- --all --limit 100
 ## Debug Stages in Service Logs
 
 - `vault_fetch`
+- `blacklist_filter`
 - `opportunity_fetch`
 - `opportunity_lookup`
 - `campaign_scan`

--- a/docs/vault-apr-debug.md
+++ b/docs/vault-apr-debug.md
@@ -1,0 +1,59 @@
+# Vault APR Debugging
+
+This workflow helps diagnose why a vault returns fallback data (`apr: 0`, `breakdown: []`) by tracing each decision stage in the APR pipeline.
+
+## Debug Env Flags
+
+Set these flags before running the API locally:
+
+```bash
+APR_DEBUG_ENABLED=true
+APR_DEBUG_VAULT_ADDRESS=0x93Fec6639717b6215A48E5a72a162C50DCC40d68 # optional
+APR_DEBUG_SAMPLE_LIMIT=50 # optional, applies when no vault filter is set
+```
+
+- `APR_DEBUG_ENABLED`: turns structured APR debug logs on.
+- `APR_DEBUG_VAULT_ADDRESS`: optional filter for one vault.
+- `APR_DEBUG_SAMPLE_LIMIT`: optional cap for unique vaults logged in one run.
+
+## Test Commands
+
+```bash
+bun run test:run -- src/app/services/aprCalcs/debugLogger.test.ts
+bun run test:run -- src/app/services/aprCalcs/utils.test.ts
+bun run test:run -- src/app/services/dataCache.test.ts
+bun run test:run -- src/app/api/vaults/route.test.ts
+```
+
+## Live Smoke Command
+
+Inspect a single vault:
+
+```bash
+bun run test:vault-debug:live -- --vault 0x93Fec6639717b6215A48E5a72a162C50DCC40d68
+```
+
+Inspect multiple vaults:
+
+```bash
+bun run test:vault-debug:live -- --all --limit 100
+```
+
+## Reason Codes
+
+- `NO_OPPORTUNITY`: no Merkl opportunity matched the vault address.
+- `NO_CAMPAIGNS`: opportunity exists but campaign list is empty.
+- `NO_APR_BREAKDOWN_MATCH`: campaigns exist, but no campaign ID matched `aprRecord.breakdowns`.
+- `TOKEN_FILTERED_OUT`: APR breakdown exists, but reward token is not in the allowlist.
+- `APR_CALCULATED`: at least one campaign passed breakdown + token filters.
+
+## Debug Stages in Service Logs
+
+- `vault_fetch`
+- `opportunity_fetch`
+- `opportunity_lookup`
+- `campaign_scan`
+- `campaign_apr_match`
+- `token_filter`
+- `result_summary`
+- `fallback`

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "bunx vitest -c vitest.config.ts",
-    "test:run": "bunx vitest run -c vitest.config.ts"
+    "test:run": "bunx vitest run -c vitest.config.ts",
+    "test:vault-debug:live": "bun scripts/debug-vault-live.ts"
   },
   "dependencies": {
     "@types/lodash": "^4.17.20",

--- a/scripts/debug-vault-live.ts
+++ b/scripts/debug-vault-live.ts
@@ -1,0 +1,363 @@
+import axios from 'axios'
+import dotenv from 'dotenv'
+import { isAddress } from 'viem'
+
+dotenv.config()
+
+const CHAIN_ID = Number.parseInt(process.env.KATANA_CHAIN_ID ?? '747474', 10)
+const YEARN_API_URL = process.env.YDAEMON_BASE_URI || 'https://ydaemon.yearn.fi'
+const MERKL_API_URL = process.env.MERKL_BASE_URI || 'https://api.merkl.xyz'
+
+const WRAPPED_KAT_ADDRESSES = [
+  '0x6E9C1F88a960fE63387eb4b71BC525a9313d8461',
+  '0x3ba1fbC4c3aEA775d335b31fb53778f46FD3a330',
+  '0x0161A31702d6CF715aaa912d64c6A190FD0093aa',
+].map((address) => address.toLowerCase())
+
+type ClassificationReason =
+  | 'NO_OPPORTUNITY'
+  | 'NO_CAMPAIGNS'
+  | 'NO_APR_BREAKDOWN_MATCH'
+  | 'TOKEN_FILTERED_OUT'
+  | 'APR_CALCULATED'
+
+interface YearnVault {
+  address: string
+  symbol: string
+  name: string
+}
+
+interface MerklCampaign {
+  campaignId?: string
+  rewardToken: {
+    address: string
+    symbol: string
+  }
+}
+
+interface MerklOpportunity {
+  identifier: string
+  name: string
+  campaigns?: MerklCampaign[]
+  aprRecord?: {
+    breakdowns?: Array<{
+      identifier?: string
+      value?: number
+    }>
+  }
+}
+
+interface VaultClassification {
+  vaultAddress: string
+  vaultName: string
+  vaultSymbol: string
+  reason: ClassificationReason
+  opportunityIdentifier?: string
+  campaignsTotal?: number
+  aprBreakdownsTotal?: number
+  matchedCampaigns?: string[]
+  filteredCampaigns?: string[]
+}
+
+const identifierMatchesAddress = (
+  identifier?: string,
+  address?: string
+): boolean => {
+  if (!identifier || !address) {
+    return false
+  }
+
+  const normalizedIdentifier = identifier.toLowerCase()
+  const normalizedAddress = address.toLowerCase()
+  return (
+    normalizedIdentifier === normalizedAddress ||
+    normalizedIdentifier.startsWith(normalizedAddress)
+  )
+}
+
+const isAllowlistedToken = (address?: string): boolean => {
+  if (!address) {
+    return false
+  }
+  return WRAPPED_KAT_ADDRESSES.includes(address.toLowerCase())
+}
+
+const classifyVault = (
+  vault: YearnVault,
+  opportunities: MerklOpportunity[]
+): VaultClassification => {
+  const opportunity = opportunities.find((opp) =>
+    identifierMatchesAddress(opp.identifier, vault.address)
+  )
+
+  if (!opportunity) {
+    return {
+      vaultAddress: vault.address,
+      vaultName: vault.name,
+      vaultSymbol: vault.symbol,
+      reason: 'NO_OPPORTUNITY',
+    }
+  }
+
+  if (!opportunity.campaigns?.length) {
+    return {
+      vaultAddress: vault.address,
+      vaultName: vault.name,
+      vaultSymbol: vault.symbol,
+      reason: 'NO_CAMPAIGNS',
+      opportunityIdentifier: opportunity.identifier,
+      campaignsTotal: 0,
+      aprBreakdownsTotal: Array.isArray(opportunity.aprRecord?.breakdowns)
+        ? opportunity.aprRecord.breakdowns.length
+        : 0,
+    }
+  }
+
+  const aprBreakdowns = Array.isArray(opportunity.aprRecord?.breakdowns)
+    ? opportunity.aprRecord.breakdowns
+    : []
+
+  let hasAprBreakdownMatch = false
+  let hasAllowlistedCampaign = false
+  const matchedCampaigns: string[] = []
+  const filteredCampaigns: string[] = []
+
+  for (const campaign of opportunity.campaigns) {
+    const campaignId = String(campaign.campaignId || '')
+    const aprBreakdown = aprBreakdowns.find(
+      (breakdown) =>
+        breakdown.identifier &&
+        breakdown.identifier.toLowerCase() === campaignId.toLowerCase() &&
+        typeof breakdown.value === 'number'
+    )
+
+    if (!aprBreakdown) {
+      continue
+    }
+
+    hasAprBreakdownMatch = true
+    if (isAllowlistedToken(campaign.rewardToken.address)) {
+      hasAllowlistedCampaign = true
+      matchedCampaigns.push(campaignId)
+    } else {
+      filteredCampaigns.push(campaignId)
+    }
+  }
+
+  if (!hasAprBreakdownMatch) {
+    return {
+      vaultAddress: vault.address,
+      vaultName: vault.name,
+      vaultSymbol: vault.symbol,
+      reason: 'NO_APR_BREAKDOWN_MATCH',
+      opportunityIdentifier: opportunity.identifier,
+      campaignsTotal: opportunity.campaigns.length,
+      aprBreakdownsTotal: aprBreakdowns.length,
+    }
+  }
+
+  if (!hasAllowlistedCampaign) {
+    return {
+      vaultAddress: vault.address,
+      vaultName: vault.name,
+      vaultSymbol: vault.symbol,
+      reason: 'TOKEN_FILTERED_OUT',
+      opportunityIdentifier: opportunity.identifier,
+      campaignsTotal: opportunity.campaigns.length,
+      aprBreakdownsTotal: aprBreakdowns.length,
+      filteredCampaigns,
+    }
+  }
+
+  return {
+    vaultAddress: vault.address,
+    vaultName: vault.name,
+    vaultSymbol: vault.symbol,
+    reason: 'APR_CALCULATED',
+    opportunityIdentifier: opportunity.identifier,
+    campaignsTotal: opportunity.campaigns.length,
+    aprBreakdownsTotal: aprBreakdowns.length,
+    matchedCampaigns,
+    filteredCampaigns,
+  }
+}
+
+const printUsage = (): void => {
+  console.log(
+    [
+      'Usage:',
+      '  bun scripts/debug-vault-live.ts --vault <0xAddress>',
+      '  bun scripts/debug-vault-live.ts --all [--limit 50]',
+      '',
+      'Examples:',
+      '  bun scripts/debug-vault-live.ts --vault 0x93Fec6639717b6215A48E5a72a162C50DCC40d68',
+      '  bun scripts/debug-vault-live.ts --all --limit 100',
+    ].join('\n')
+  )
+}
+
+const parseArgs = (): {
+  vaultAddress?: string
+  inspectAll: boolean
+  limit: number
+} => {
+  const args = process.argv.slice(2)
+  let vaultAddress: string | undefined
+  let inspectAll = false
+  let limit = 25
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]
+    if (arg === '--vault') {
+      vaultAddress = args[i + 1]
+      i += 1
+      continue
+    }
+    if (arg === '--all') {
+      inspectAll = true
+      continue
+    }
+    if (arg === '--limit') {
+      const parsedLimit = Number.parseInt(args[i + 1] ?? '', 10)
+      if (!Number.isFinite(parsedLimit) || parsedLimit < 1) {
+        throw new Error('--limit must be a positive integer')
+      }
+      limit = parsedLimit
+      i += 1
+      continue
+    }
+    if (arg === '--help' || arg === '-h') {
+      printUsage()
+      process.exit(0)
+    }
+  }
+
+  if (vaultAddress && !isAddress(vaultAddress)) {
+    throw new Error(`Invalid vault address: ${vaultAddress}`)
+  }
+
+  if (!vaultAddress && !inspectAll) {
+    inspectAll = true
+  }
+
+  return { vaultAddress, inspectAll, limit }
+}
+
+const fetchYearnVaults = async (): Promise<YearnVault[]> => {
+  const params = new URLSearchParams({
+    hideAlways: 'true',
+    orderBy: 'featuringScore',
+    orderDirection: 'desc',
+    strategiesDetails: 'withDetails',
+    strategiesCondition: 'inQueue',
+    chainIDs: CHAIN_ID.toString(),
+    limit: '2500',
+  })
+
+  const response = await axios.get<YearnVault[]>(
+    `${YEARN_API_URL}/vaults/katana?${params}`
+  )
+
+  return response.data || []
+}
+
+const fetchMerklOpportunities = async (): Promise<MerklOpportunity[]> => {
+  const response = await axios.get<
+    MerklOpportunity[] | { opportunities: MerklOpportunity[] }
+  >(`${MERKL_API_URL}/v4/opportunities`, {
+    params: {
+      status: 'LIVE',
+      chainId: CHAIN_ID,
+      type: 'ERC20LOGPROCESSOR',
+      campaigns: true,
+    },
+  })
+
+  return Array.isArray(response.data)
+    ? response.data
+    : response.data.opportunities || []
+}
+
+const buildSummary = (
+  classifications: VaultClassification[]
+): Record<ClassificationReason, number> => ({
+  NO_OPPORTUNITY: classifications.filter((item) => item.reason === 'NO_OPPORTUNITY')
+    .length,
+  NO_CAMPAIGNS: classifications.filter((item) => item.reason === 'NO_CAMPAIGNS')
+    .length,
+  NO_APR_BREAKDOWN_MATCH: classifications.filter(
+    (item) => item.reason === 'NO_APR_BREAKDOWN_MATCH'
+  ).length,
+  TOKEN_FILTERED_OUT: classifications.filter(
+    (item) => item.reason === 'TOKEN_FILTERED_OUT'
+  ).length,
+  APR_CALCULATED: classifications.filter((item) => item.reason === 'APR_CALCULATED')
+    .length,
+})
+
+const main = async (): Promise<void> => {
+  const { vaultAddress, inspectAll, limit } = parseArgs()
+
+  const [vaults, opportunities] = await Promise.all([
+    fetchYearnVaults(),
+    fetchMerklOpportunities(),
+  ])
+
+  const selectedVaults = vaultAddress
+    ? vaults.filter(
+        (vault) => vault.address.toLowerCase() === vaultAddress.toLowerCase()
+      )
+    : inspectAll
+      ? vaults.slice(0, limit)
+      : []
+
+  if (selectedVaults.length === 0) {
+    console.log(
+      JSON.stringify(
+        {
+          chainId: CHAIN_ID,
+          selectedVaults: 0,
+          message: vaultAddress
+            ? 'No vault matched the provided address in yDaemon response'
+            : 'No vaults selected',
+        },
+        null,
+        2
+      )
+    )
+    return
+  }
+
+  const classifications = selectedVaults.map((vault) =>
+    classifyVault(vault, opportunities)
+  )
+
+  console.log(
+    JSON.stringify(
+      {
+        chainId: CHAIN_ID,
+        yearnVaultCount: vaults.length,
+        merklOpportunityCount: opportunities.length,
+        selectedVaults: selectedVaults.length,
+        summary: buildSummary(classifications),
+        results: classifications,
+      },
+      null,
+      2
+    )
+  )
+}
+
+main().catch((error) => {
+  console.error(
+    JSON.stringify(
+      {
+        message: 'Vault debug run failed',
+        error: error instanceof Error ? error.message : String(error),
+      },
+      null,
+      2
+    )
+  )
+  process.exit(1)
+})

--- a/src/app/api/vaults/route.test.ts
+++ b/src/app/api/vaults/route.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  mockGenerateVaultAPRData: vi.fn(),
+}))
+
+vi.mock('../../services/dataCache', () => ({
+  DataCacheService: vi.fn().mockImplementation(() => ({
+    generateVaultAPRData: mocks.mockGenerateVaultAPRData,
+  })),
+}))
+
+import { GET, OPTIONS } from './route'
+
+describe('/api/vaults route', () => {
+  beforeEach(() => {
+    mocks.mockGenerateVaultAPRData.mockReset()
+  })
+
+  it('returns APR data with cache and CORS headers on success', async () => {
+    const payload = {
+      '0x00000000000000000000000000000000000000aa': {
+        name: 'Vault',
+        apr: 0,
+        breakdown: [],
+      },
+    }
+
+    mocks.mockGenerateVaultAPRData.mockResolvedValue(payload)
+
+    const response = await GET()
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual(payload)
+    expect(response.headers.get('Cache-Control')).toContain('s-maxage=900')
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
+  })
+
+  it('returns 502 with error payload when data generation fails', async () => {
+    mocks.mockGenerateVaultAPRData.mockRejectedValue(new Error('upstream failed'))
+
+    const response = await GET()
+    const body = await response.json()
+
+    expect(response.status).toBe(502)
+    expect(body).toEqual({
+      message: 'An error occurred while fetching data.',
+      error: 'upstream failed',
+    })
+    expect(response.headers.get('Cache-Control')).toBe('no-store')
+  })
+
+  it('handles OPTIONS requests for CORS preflight', async () => {
+    const response = OPTIONS()
+
+    expect(response.status).toBe(204)
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
+    expect(response.headers.get('Access-Control-Allow-Methods')).toContain('GET')
+  })
+})

--- a/src/app/config/index.ts
+++ b/src/app/config/index.ts
@@ -1,8 +1,19 @@
-import { createConfig } from '@wagmi/core';
-import dotenv from 'dotenv';
-import { defineChain, http } from 'viem';
+import { createConfig } from '@wagmi/core'
+import dotenv from 'dotenv'
+import { defineChain, http } from 'viem'
 
-dotenv.config();
+dotenv.config()
+
+const parseBoolean = (value?: string): boolean => value === 'true'
+
+const parsePositiveInteger = (value?: string): number | undefined => {
+  if (!value) {
+    return undefined
+  }
+
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
+}
 
 export const config = {
   port: process.env.PORT || 3000,
@@ -11,9 +22,12 @@ export const config = {
   rpcUrl: process.env.RPC_URL_KATANA!,
   yearnApiUrl: process.env.YDAEMON_BASE_URI || 'https://ydaemon.yearn.fi',
   merklApiUrl: process.env.MERKL_BASE_URI || 'https://api.merkl.xyz',
+  aprDebugEnabled: parseBoolean(process.env.APR_DEBUG_ENABLED),
+  aprDebugVaultAddress: process.env.APR_DEBUG_VAULT_ADDRESS?.toLowerCase(),
+  aprDebugSampleLimit: parsePositiveInteger(process.env.APR_DEBUG_SAMPLE_LIMIT),
   katanaTokenFDV: 1_000_000_000, // 1B FDV default
   multicallAddress: '0xcA11bde05977b3631167028862bE2a173976CA11' as const,
-};
+}
 
 export const katana = defineChain({
   id: 747474,
@@ -34,11 +48,11 @@ export const katana = defineChain({
       blockCreated: 0,
     },
   },
-});
+})
 
 export const wagmiConfig = createConfig({
   chains: [katana],
   transports: {
     [katana.id]: http(config.rpcUrl),
   },
-});
+})

--- a/src/app/services/aprCalcs/debugLogger.test.ts
+++ b/src/app/services/aprCalcs/debugLogger.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest'
+
+interface DebugConfigOverrides {
+  aprDebugEnabled?: boolean
+  aprDebugVaultAddress?: string
+  aprDebugSampleLimit?: number
+}
+
+const loadDebugLogger = async (overrides: DebugConfigOverrides = {}) => {
+  vi.resetModules()
+  vi.doMock('../../config', () => ({
+    config: {
+      aprDebugEnabled: false,
+      aprDebugVaultAddress: undefined,
+      aprDebugSampleLimit: undefined,
+      ...overrides,
+    },
+  }))
+
+  return await import('./debugLogger')
+}
+
+describe('debugLogger', () => {
+  it('does not emit logs when debug is disabled', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const { logVaultAprDebug } = await loadDebugLogger({
+      aprDebugEnabled: false,
+    })
+
+    logVaultAprDebug({
+      stage: 'result_summary',
+      vaultAddress: '0x0000000000000000000000000000000000000001',
+      reason: 'test',
+    })
+
+    expect(logSpy).not.toHaveBeenCalled()
+    logSpy.mockRestore()
+  })
+
+  it('emits logs when debug is enabled', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const { logVaultAprDebug } = await loadDebugLogger({
+      aprDebugEnabled: true,
+    })
+
+    logVaultAprDebug({
+      stage: 'result_summary',
+      vaultAddress: '0x0000000000000000000000000000000000000001',
+      reason: 'test',
+    })
+
+    expect(logSpy).toHaveBeenCalledTimes(1)
+    logSpy.mockRestore()
+  })
+
+  it('applies a vault-address filter', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const targetAddress = '0x0000000000000000000000000000000000000001'
+    const { logVaultAprDebug } = await loadDebugLogger({
+      aprDebugEnabled: true,
+      aprDebugVaultAddress: targetAddress.toLowerCase(),
+    })
+
+    logVaultAprDebug({
+      stage: 'result_summary',
+      vaultAddress: targetAddress.toUpperCase(),
+      reason: 'match',
+    })
+    logVaultAprDebug({
+      stage: 'result_summary',
+      vaultAddress: '0x0000000000000000000000000000000000000002',
+      reason: 'miss',
+    })
+
+    expect(logSpy).toHaveBeenCalledTimes(1)
+    logSpy.mockRestore()
+  })
+
+  it('enforces unique-vault sampling limits', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const { logVaultAprDebug, resetVaultAprDebugStateForTests } =
+      await loadDebugLogger({
+        aprDebugEnabled: true,
+        aprDebugSampleLimit: 1,
+      })
+
+    resetVaultAprDebugStateForTests()
+
+    logVaultAprDebug({
+      stage: 'result_summary',
+      vaultAddress: '0x0000000000000000000000000000000000000001',
+      reason: 'first-address',
+    })
+    logVaultAprDebug({
+      stage: 'result_summary',
+      vaultAddress: '0x0000000000000000000000000000000000000002',
+      reason: 'second-address-blocked',
+    })
+    logVaultAprDebug({
+      stage: 'result_summary',
+      vaultAddress: '0x0000000000000000000000000000000000000001',
+      reason: 'first-address-repeat',
+    })
+
+    expect(logSpy).toHaveBeenCalledTimes(2)
+    logSpy.mockRestore()
+  })
+})

--- a/src/app/services/aprCalcs/debugLogger.ts
+++ b/src/app/services/aprCalcs/debugLogger.ts
@@ -47,17 +47,107 @@ export const shouldLogVaultAprDebug = (vaultAddress?: string): boolean => {
   return matchesVaultFilter(vaultAddress) && isWithinSampleLimit(vaultAddress)
 }
 
+const shortenAddress = (address?: string): string => {
+  if (!address) {
+    return 'unknown'
+  }
+
+  if (address.length <= 12) {
+    return address
+  }
+
+  return `${address.slice(0, 6)}...${address.slice(-4)}`
+}
+
+const formatCampaignId = (campaignId?: string): string =>
+  campaignId ? campaignId : 'unknown-campaign'
+
+const formatVaultLabel = (event: VaultAprDebugEvent): string => {
+  const shortAddress = shortenAddress(event.vaultAddress)
+  return event.vaultName
+    ? `${event.vaultName} (${shortAddress})`
+    : shortAddress
+}
+
+const formatDebugEvent = (event: VaultAprDebugEvent): string | null => {
+  const vaultLabel = formatVaultLabel(event)
+
+  switch (event.stage) {
+    case 'vault_fetch':
+      return `👀 Vault fetched: ${vaultLabel}${
+        event.vaultSymbol ? ` [${event.vaultSymbol}]` : ''
+      } (total vaults: ${event.totalVaults ?? '?'})`
+    case 'blacklist_filter':
+      return `⛔ Blacklist removed ${event.blacklistedCampaigns ?? 0} campaign(s) for ${vaultLabel}. APR-linked removals: ${
+        event.blacklistedAprBreakdownCampaignIds?.length ?? 0
+      }`
+    case 'opportunity_fetch':
+      return `📦 Opportunity loaded for ${vaultLabel}: ${
+        event.opportunityType ?? event.poolType ?? 'unknown'
+      } with ${event.campaignsTotal ?? 0} campaign(s)`
+    case 'opportunity_lookup':
+      if (event.reason === 'opportunity_found') {
+        return `🎯 Opportunity found for ${vaultLabel} (${event.poolType ?? 'unknown'}): ${shortenAddress(
+          event.opportunityIdentifier
+        )}`
+      }
+      return `🔍 No opportunity found for ${vaultLabel} (${event.poolType ?? 'unknown'})`
+    case 'campaign_scan':
+      return `🧮 Scanning ${event.campaignsTotal ?? 0} campaign(s) and ${
+        event.aprBreakdownsTotal ?? 0
+      } APR breakdown(s) for ${vaultLabel}`
+    case 'campaign_apr_match':
+      if (!event.aprBreakdownMatched) {
+        return null
+      }
+      return `📊 Campaign ${formatCampaignId(
+        event.campaignId
+      )} has APR breakdown${typeof event.aprValue === 'number' ? ` (${event.aprValue.toFixed(4)}%)` : ''}`
+    case 'token_filter':
+      return `   ${
+        event.tokenMatched ? '✅' : '❌'
+      } Token ${event.rewardTokenSymbol ?? 'unknown'} (${shortenAddress(
+        event.rewardTokenAddress
+      )}) ${event.tokenMatched ? 'accepted' : 'filtered'}`
+    case 'result_summary':
+      if (event.reason === 'apr_calculated') {
+        return `📋 Summary for ${vaultLabel}: ${
+          event.acceptedCampaigns ?? 0
+        } campaign(s) contributed APR`
+      }
+      if (event.reason === 'no_matching_campaigns_after_filters') {
+        return `📋 Summary for ${vaultLabel}: campaigns exist but none matched APR + token filters`
+      }
+      if (event.reason === 'vault_results_aggregated') {
+        return `✅ Vault aggregated for ${vaultLabel} with ${
+          event.acceptedCampaigns ?? 0
+        } result entry(ies)`
+      }
+      if (event.reason === 'opportunity_missing') {
+        return `📋 Summary for ${vaultLabel}: no matching opportunity`
+      }
+      if (event.reason === 'opportunity_has_no_campaigns') {
+        return `📋 Summary for ${vaultLabel}: opportunity has no campaigns`
+      }
+      return `📋 Summary for ${vaultLabel}: ${event.reason ?? 'completed'}`
+    case 'fallback':
+      return `⚠️ Fallback used for ${vaultLabel}: ${event.reason ?? 'unknown_reason'}`
+    default:
+      return `${event.stage}: ${event.reason ?? 'event'}`
+  }
+}
+
 export const logVaultAprDebug = (event: VaultAprDebugEvent): void => {
   if (!shouldLogVaultAprDebug(event.vaultAddress)) {
     return
   }
 
-  const payload = {
-    ts: new Date().toISOString(),
-    ...event,
+  const message = formatDebugEvent(event)
+  if (!message) {
+    return
   }
 
-  console.log(`[apr-debug] ${JSON.stringify(payload)}`)
+  console.log(`[apr-debug] ${message}`)
 }
 
 export const resetVaultAprDebugStateForTests = (): void => {

--- a/src/app/services/aprCalcs/debugLogger.ts
+++ b/src/app/services/aprCalcs/debugLogger.ts
@@ -1,0 +1,65 @@
+import { config } from '../../config'
+import type { VaultAprDebugEvent } from './types'
+
+const sampledVaultAddresses = new Set<string>()
+
+const normalizeAddress = (address: string): string => address.toLowerCase()
+
+const matchesVaultFilter = (vaultAddress?: string): boolean => {
+  if (!config.aprDebugVaultAddress) {
+    return true
+  }
+
+  if (!vaultAddress) {
+    return false
+  }
+
+  return normalizeAddress(vaultAddress) === config.aprDebugVaultAddress
+}
+
+const isWithinSampleLimit = (vaultAddress?: string): boolean => {
+  if (!config.aprDebugSampleLimit) {
+    return true
+  }
+
+  if (!vaultAddress) {
+    return false
+  }
+
+  const normalizedVaultAddress = normalizeAddress(vaultAddress)
+  if (sampledVaultAddresses.has(normalizedVaultAddress)) {
+    return true
+  }
+
+  if (sampledVaultAddresses.size >= config.aprDebugSampleLimit) {
+    return false
+  }
+
+  sampledVaultAddresses.add(normalizedVaultAddress)
+  return true
+}
+
+export const shouldLogVaultAprDebug = (vaultAddress?: string): boolean => {
+  if (!config.aprDebugEnabled) {
+    return false
+  }
+
+  return matchesVaultFilter(vaultAddress) && isWithinSampleLimit(vaultAddress)
+}
+
+export const logVaultAprDebug = (event: VaultAprDebugEvent): void => {
+  if (!shouldLogVaultAprDebug(event.vaultAddress)) {
+    return
+  }
+
+  const payload = {
+    ts: new Date().toISOString(),
+    ...event,
+  }
+
+  console.log(`[apr-debug] ${JSON.stringify(payload)}`)
+}
+
+export const resetVaultAprDebugStateForTests = (): void => {
+  sampledVaultAddresses.clear()
+}

--- a/src/app/services/aprCalcs/types.ts
+++ b/src/app/services/aprCalcs/types.ts
@@ -47,14 +47,15 @@ export interface Opportunity {
   apr?: number
   aprRecord?: {
     breakdowns?: Array<{
-      identifier: string
-      value: number
+      identifier?: string
+      value?: number
     }>
   }
 }
 
 export type VaultAprDebugStage =
   | 'vault_fetch'
+  | 'blacklist_filter'
   | 'opportunity_fetch'
   | 'opportunity_lookup'
   | 'campaign_scan'
@@ -82,6 +83,9 @@ export interface VaultAprDebugEvent {
   tokenMatched?: boolean
   aprValue?: number
   acceptedCampaigns?: number
+  blacklistedCampaigns?: number
+  blacklistedCampaignIds?: string[]
+  blacklistedAprBreakdownCampaignIds?: string[]
   totalVaults?: number
   withResults?: number
   fallbackCount?: number

--- a/src/app/services/aprCalcs/types.ts
+++ b/src/app/services/aprCalcs/types.ts
@@ -52,3 +52,38 @@ export interface Opportunity {
     }>
   }
 }
+
+export type VaultAprDebugStage =
+  | 'vault_fetch'
+  | 'opportunity_fetch'
+  | 'opportunity_lookup'
+  | 'campaign_scan'
+  | 'campaign_apr_match'
+  | 'token_filter'
+  | 'result_summary'
+  | 'fallback'
+
+export interface VaultAprDebugEvent {
+  stage: VaultAprDebugStage
+  vaultAddress?: string
+  vaultName?: string
+  vaultSymbol?: string
+  chainId?: number
+  poolType?: string
+  opportunityType?: string
+  opportunityIdentifier?: string
+  opportunitiesTotal?: number
+  campaignId?: string
+  campaignsTotal?: number
+  aprBreakdownsTotal?: number
+  rewardTokenAddress?: string
+  rewardTokenSymbol?: string
+  aprBreakdownMatched?: boolean
+  tokenMatched?: boolean
+  aprValue?: number
+  acceptedCampaigns?: number
+  totalVaults?: number
+  withResults?: number
+  fallbackCount?: number
+  reason?: string
+}

--- a/src/app/services/aprCalcs/utils.test.ts
+++ b/src/app/services/aprCalcs/utils.test.ts
@@ -116,7 +116,7 @@ describe('calculateYearnVaultRewardsAPR', () => {
     )
   })
 
-  it('returns an empty list when campaigns have no APR breakdown match', () => {
+  it('returns a zero placeholder when campaigns have no APR breakdown match', () => {
     const results = calculateYearnVaultRewardsAPR(
       'Vault',
       VAULT_ADDRESS,
@@ -131,7 +131,22 @@ describe('calculateYearnVaultRewardsAPR', () => {
       [WRAPPED_KAT_ADDRESS],
     )
 
-    expect(results).toEqual([])
+    expect(results).toEqual([
+      {
+        vaultName: 'Vault',
+        vaultAddress: VAULT_ADDRESS,
+        poolType: 'yearn',
+        breakdown: {
+          apr: 0,
+          token: {
+            address: '',
+            symbol: '',
+            decimals: 0,
+          },
+          weight: 0,
+        },
+      },
+    ])
     expect(mocks.logVaultAprDebug).toHaveBeenCalledWith(
       expect.objectContaining({
         stage: 'campaign_apr_match',
@@ -146,7 +161,7 @@ describe('calculateYearnVaultRewardsAPR', () => {
     )
   })
 
-  it('returns an empty list when APR exists but reward token is filtered out', () => {
+  it('returns a zero placeholder when APR exists but reward token is filtered out', () => {
     const results = calculateYearnVaultRewardsAPR(
       'Vault',
       VAULT_ADDRESS,
@@ -168,7 +183,22 @@ describe('calculateYearnVaultRewardsAPR', () => {
       [WRAPPED_KAT_ADDRESS],
     )
 
-    expect(results).toEqual([])
+    expect(results).toEqual([
+      {
+        vaultName: 'Vault',
+        vaultAddress: VAULT_ADDRESS,
+        poolType: 'yearn',
+        breakdown: {
+          apr: 0,
+          token: {
+            address: '',
+            symbol: '',
+            decimals: 0,
+          },
+          weight: 0,
+        },
+      },
+    ])
     expect(mocks.logVaultAprDebug).toHaveBeenCalledWith(
       expect.objectContaining({
         stage: 'token_filter',

--- a/src/app/services/aprCalcs/utils.test.ts
+++ b/src/app/services/aprCalcs/utils.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Opportunity } from './types'
+
+const mocks = vi.hoisted(() => ({
+  logVaultAprDebug: vi.fn(),
+}))
+
+vi.mock('./debugLogger', () => ({
+  logVaultAprDebug: mocks.logVaultAprDebug,
+}))
+
+import { calculateYearnVaultRewardsAPR } from './utils'
+
+const VAULT_ADDRESS = '0x00000000000000000000000000000000000000aa'
+const WRAPPED_KAT_ADDRESS = '0x00000000000000000000000000000000000000bb'
+const NON_ALLOWLIST_TOKEN = '0x00000000000000000000000000000000000000cc'
+
+const makeOpportunity = (overrides: Partial<Opportunity> = {}): Opportunity => ({
+  name: 'Test Opportunity',
+  identifier: VAULT_ADDRESS,
+  campaigns: [
+    {
+      campaignId: 'campaign-1',
+      rewardToken: {
+        address: WRAPPED_KAT_ADDRESS,
+        symbol: 'KAT',
+        decimals: 18,
+      },
+    },
+  ],
+  aprRecord: {
+    breakdowns: [
+      {
+        identifier: 'campaign-1',
+        value: 12.5,
+      },
+    ],
+  },
+  ...overrides,
+})
+
+describe('calculateYearnVaultRewardsAPR', () => {
+  beforeEach(() => {
+    mocks.logVaultAprDebug.mockClear()
+  })
+
+  it('returns zero placeholder when no opportunity is found', () => {
+    const results = calculateYearnVaultRewardsAPR(
+      'Vault',
+      VAULT_ADDRESS,
+      [],
+      'yearn',
+      [WRAPPED_KAT_ADDRESS],
+    )
+
+    expect(results).toEqual([
+      {
+        vaultName: 'Vault',
+        vaultAddress: VAULT_ADDRESS,
+        poolType: 'yearn',
+        breakdown: {
+          apr: 0,
+          token: {
+            address: '',
+            symbol: '',
+            decimals: 0,
+          },
+          weight: 0,
+        },
+      },
+    ])
+    expect(mocks.logVaultAprDebug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: 'opportunity_lookup',
+        reason: 'opportunity_missing',
+      }),
+    )
+    expect(mocks.logVaultAprDebug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: 'result_summary',
+        reason: 'opportunity_missing',
+      }),
+    )
+  })
+
+  it('returns zero placeholder when opportunity has no campaigns', () => {
+    const results = calculateYearnVaultRewardsAPR(
+      'Vault',
+      VAULT_ADDRESS,
+      [makeOpportunity({ campaigns: [] })],
+      'yearn',
+      [WRAPPED_KAT_ADDRESS],
+    )
+
+    expect(results).toEqual([
+      {
+        vaultName: 'Vault',
+        vaultAddress: VAULT_ADDRESS,
+        poolType: 'yearn',
+        breakdown: {
+          apr: 0,
+          token: {
+            address: '',
+            symbol: '',
+            decimals: 0,
+          },
+          weight: 0,
+        },
+      },
+    ])
+    expect(mocks.logVaultAprDebug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: 'result_summary',
+        reason: 'opportunity_has_no_campaigns',
+      }),
+    )
+  })
+
+  it('returns an empty list when campaigns have no APR breakdown match', () => {
+    const results = calculateYearnVaultRewardsAPR(
+      'Vault',
+      VAULT_ADDRESS,
+      [
+        makeOpportunity({
+          aprRecord: {
+            breakdowns: [],
+          },
+        }),
+      ],
+      'yearn',
+      [WRAPPED_KAT_ADDRESS],
+    )
+
+    expect(results).toEqual([])
+    expect(mocks.logVaultAprDebug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: 'campaign_apr_match',
+        aprBreakdownMatched: false,
+      }),
+    )
+    expect(mocks.logVaultAprDebug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: 'result_summary',
+        reason: 'no_matching_campaigns_after_filters',
+      }),
+    )
+  })
+
+  it('returns an empty list when APR exists but reward token is filtered out', () => {
+    const results = calculateYearnVaultRewardsAPR(
+      'Vault',
+      VAULT_ADDRESS,
+      [
+        makeOpportunity({
+          campaigns: [
+            {
+              campaignId: 'campaign-1',
+              rewardToken: {
+                address: NON_ALLOWLIST_TOKEN,
+                symbol: 'OTHER',
+                decimals: 18,
+              },
+            },
+          ],
+        }),
+      ],
+      'yearn',
+      [WRAPPED_KAT_ADDRESS],
+    )
+
+    expect(results).toEqual([])
+    expect(mocks.logVaultAprDebug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: 'token_filter',
+        tokenMatched: false,
+        reason: 'reward_token_filtered',
+      }),
+    )
+  })
+
+  it('returns campaign APR breakdown when campaign and token match', () => {
+    const results = calculateYearnVaultRewardsAPR(
+      'Vault',
+      VAULT_ADDRESS,
+      [makeOpportunity()],
+      'yearn',
+      [WRAPPED_KAT_ADDRESS],
+    )
+
+    expect(results).toEqual([
+      {
+        vaultName: 'Vault',
+        vaultAddress: VAULT_ADDRESS,
+        poolType: 'yearn',
+        breakdown: {
+          apr: 12.5,
+          token: {
+            address: WRAPPED_KAT_ADDRESS,
+            symbol: 'KAT',
+            decimals: 18,
+          },
+          weight: 0,
+        },
+      },
+    ])
+    expect(mocks.logVaultAprDebug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: 'result_summary',
+        reason: 'apr_calculated',
+        acceptedCampaigns: 1,
+      }),
+    )
+  })
+})

--- a/src/app/services/aprCalcs/utils.ts
+++ b/src/app/services/aprCalcs/utils.ts
@@ -180,6 +180,23 @@ export const calculateYearnVaultRewardsAPR = (
   poolType: string,
   targetRewardTokenAddress: string[]
 ): YearnRewardCalculatorResult[] | null => {
+  const zeroPlaceholderResult: YearnRewardCalculatorResult[] = [
+    {
+      vaultName,
+      vaultAddress,
+      poolType,
+      breakdown: {
+        apr: 0,
+        token: {
+          address: '',
+          symbol: '',
+          decimals: 0,
+        },
+        weight: 0,
+      },
+    },
+  ]
+
   if (!vaultAddress) {
     logVaultAprDebug({
       stage: 'result_summary',
@@ -218,22 +235,7 @@ export const calculateYearnVaultRewardsAPR = (
       reason,
     })
     // Return a result with 0 APR and null token details
-    return [
-      {
-        vaultName,
-        vaultAddress,
-        poolType,
-        breakdown: {
-          apr: 0,
-          token: {
-            address: '',
-            symbol: '',
-            decimals: 0,
-          },
-          weight: 0,
-        },
-      },
-    ]
+    return zeroPlaceholderResult
   }
 
   const aprBreakdowns = Array.isArray(opportunity.aprRecord?.breakdowns)
@@ -343,6 +345,10 @@ export const calculateYearnVaultRewardsAPR = (
         ? 'apr_calculated'
         : 'no_matching_campaigns_after_filters',
   })
+
+  if (combined.length === 0) {
+    return zeroPlaceholderResult
+  }
 
   return combined
 }

--- a/src/app/services/aprCalcs/utils.ts
+++ b/src/app/services/aprCalcs/utils.ts
@@ -265,8 +265,11 @@ export const calculateYearnVaultRewardsAPR = (
           b.identifier.toLowerCase() === String(campaignId).toLowerCase()
       )
 
-      const aprBreakdownMatched =
-        !!aprBreakdown && typeof aprBreakdown.value === 'number'
+      const aprValue =
+        aprBreakdown && typeof aprBreakdown.value === 'number'
+          ? aprBreakdown.value
+          : undefined
+      const aprBreakdownMatched = aprValue !== undefined
 
       logVaultAprDebug({
         stage: 'campaign_apr_match',
@@ -278,13 +281,13 @@ export const calculateYearnVaultRewardsAPR = (
         rewardTokenAddress: campaign.rewardToken.address,
         rewardTokenSymbol: campaign.rewardToken.symbol,
         aprBreakdownMatched,
-        aprValue: aprBreakdownMatched ? aprBreakdown.value : undefined,
+        aprValue,
         reason: aprBreakdownMatched
           ? 'campaign_apr_breakdown_found'
           : 'campaign_apr_breakdown_missing',
       })
 
-      if (!aprBreakdownMatched) {
+      if (aprValue === undefined) {
         continue
       }
 
@@ -302,12 +305,12 @@ export const calculateYearnVaultRewardsAPR = (
         rewardTokenAddress: campaign.rewardToken.address,
         rewardTokenSymbol: campaign.rewardToken.symbol,
         tokenMatched: tokenMatches,
-        aprValue: aprBreakdown.value,
+        aprValue,
         reason: tokenMatches ? 'reward_token_allowed' : 'reward_token_filtered',
       })
 
       if (tokenMatches) {
-        vaultAprValues.push({ apr: aprBreakdown.value, campaign })
+        vaultAprValues.push({ apr: aprValue, campaign })
       }
     }
   }

--- a/src/app/services/aprCalcs/utils.ts
+++ b/src/app/services/aprCalcs/utils.ts
@@ -5,6 +5,7 @@ import type {
   RewardCalculatorResult,
   YearnRewardCalculatorResult,
 } from './types'
+import { logVaultAprDebug } from './debugLogger'
 
 /**
  * Shortens an Ethereum address to display format (0x1234...5678)
@@ -169,7 +170,6 @@ export const calculateStrategyAPR = (
  * @param opportunities - Array of available opportunities containing campaigns and APR records.
  * @param poolType - The type of pool (e.g., 'morpho') for which APR is being calculated.
  * @param targetRewardTokenAddress - Array of addresses of the reward tokens to filter campaigns by.
- * @param enableLogging - Whether to enable debug logging for this calculation.
  * @returns An array of YearnRewardCalculatorResult objects containing APR breakdowns for each matching campaign,
  *          or null if no opportunity is found for the vault address.
  */
@@ -178,39 +178,45 @@ export const calculateYearnVaultRewardsAPR = (
   vaultAddress: string,
   opportunities: Opportunity[],
   poolType: string,
-  targetRewardTokenAddress: string[],
-  enableLogging: boolean = false
+  targetRewardTokenAddress: string[]
 ): YearnRewardCalculatorResult[] | null => {
-  // Helper function to conditionally log
-  const log = (...args: Parameters<typeof console.log>) => {
-    if (enableLogging) {
-      console.log(...args)
-    }
-  }
-
   if (!vaultAddress) {
-    log('🚫 No vault address provided')
+    logVaultAprDebug({
+      stage: 'result_summary',
+      vaultName,
+      poolType,
+      reason: 'missing_vault_address',
+    })
     return null
   }
-
-  log(`\n👀 Analyzing vault: ${vaultName} (${shortenAddress(vaultAddress)})`)
 
   const opportunity = opportunities.find((opp) =>
     identifierMatchesAddress(opp.identifier, vaultAddress)
   )
 
-  if (opportunity) {
-    log(`\n🎯 Found Opportunity: ${opportunity.name}`)
-    log('═'.repeat(50))
-  }
+  logVaultAprDebug({
+    stage: 'opportunity_lookup',
+    vaultAddress,
+    vaultName,
+    poolType,
+    opportunityIdentifier: opportunity?.identifier,
+    campaignsTotal: opportunity?.campaigns?.length || 0,
+    opportunitiesTotal: opportunities.length,
+    reason: opportunity ? 'opportunity_found' : 'opportunity_missing',
+  })
 
   if (!opportunity?.campaigns?.length) {
-    log(
-      `🔍 No ${poolType} opportunity found for vault: ${vaultName} (${shortenAddress(
-        vaultAddress
-      )})`
-    )
-    log('═'.repeat(50))
+    const reason = opportunity ? 'opportunity_has_no_campaigns' : 'opportunity_missing'
+    logVaultAprDebug({
+      stage: 'result_summary',
+      vaultAddress,
+      vaultName,
+      poolType,
+      opportunitiesTotal: opportunities.length,
+      campaignsTotal: opportunity?.campaigns?.length || 0,
+      acceptedCampaigns: 0,
+      reason,
+    })
     // Return a result with 0 APR and null token details
     return [
       {
@@ -230,60 +236,79 @@ export const calculateYearnVaultRewardsAPR = (
     ]
   }
 
+  const aprBreakdowns = Array.isArray(opportunity.aprRecord?.breakdowns)
+    ? opportunity.aprRecord?.breakdowns
+    : []
+
+  logVaultAprDebug({
+    stage: 'campaign_scan',
+    vaultAddress,
+    vaultName,
+    poolType,
+    opportunityIdentifier: opportunity.identifier,
+    campaignsTotal: opportunity.campaigns.length,
+    aprBreakdownsTotal: aprBreakdowns.length,
+    reason: 'scanning_campaigns',
+  })
+
   // First check each campaign to see if its campaignId exists in aprRecord.breakdowns,
   // then confirm the token matches
   const vaultAprValues: Array<{ apr: number; campaign: Campaign }> = []
-  if (
-    opportunity.aprRecord &&
-    Array.isArray(opportunity.aprRecord.breakdowns) &&
-    opportunity.campaigns.length > 0
-  ) {
+  if (opportunity.campaigns.length > 0) {
     for (const campaign of opportunity.campaigns) {
       const campaignId = campaign.campaignId
-      const aprBreakdown = opportunity.aprRecord.breakdowns.find(
-        (b: { identifier?: string; value?: number }) => {
-          const isMatch =
-            b.identifier &&
-            b.identifier.toLowerCase() === String(campaignId).toLowerCase()
-          return isMatch
-        }
+      const aprBreakdown = aprBreakdowns.find(
+        (b: { identifier?: string; value?: number }) =>
+          b.identifier &&
+          b.identifier.toLowerCase() === String(campaignId).toLowerCase()
       )
 
-      // If campaign has APR breakdown and token matches, include it
-      if (aprBreakdown && typeof aprBreakdown.value === 'number') {
-        log(`📊 Campaign ${campaignId}:`)
-        log(
-          `   💰 Token: ${shortenAddress(campaign.rewardToken.address)} (${
-            campaign.rewardToken.symbol
-          })`
-        )
-        log(
-          `   🎯 Target Tokens: [${targetRewardTokenAddress
-            .map((addr) => shortenAddress(addr))
-            .join(', ')}]`
-        )
-        log(`   📈 APR: ${aprBreakdown.value.toFixed(4)}%`)
+      const aprBreakdownMatched =
+        !!aprBreakdown && typeof aprBreakdown.value === 'number'
 
-        const tokenMatches = targetRewardTokenAddress.some((addr) =>
-          safeIsAddressEqual(campaign.rewardToken.address, addr)
-        )
+      logVaultAprDebug({
+        stage: 'campaign_apr_match',
+        vaultAddress,
+        vaultName,
+        poolType,
+        opportunityIdentifier: opportunity.identifier,
+        campaignId,
+        rewardTokenAddress: campaign.rewardToken.address,
+        rewardTokenSymbol: campaign.rewardToken.symbol,
+        aprBreakdownMatched,
+        aprValue: aprBreakdownMatched ? aprBreakdown.value : undefined,
+        reason: aprBreakdownMatched
+          ? 'campaign_apr_breakdown_found'
+          : 'campaign_apr_breakdown_missing',
+      })
 
-        log(`   ${tokenMatches ? '✅' : '❌'} Token match: ${tokenMatches}`)
+      if (!aprBreakdownMatched) {
+        continue
+      }
 
-        if (tokenMatches) {
-          log(`   ➕ Adding campaign ${campaignId} to vault APR values`)
-          vaultAprValues.push({ apr: aprBreakdown.value, campaign })
-        }
+      const tokenMatches = targetRewardTokenAddress.some((addr) =>
+        safeIsAddressEqual(campaign.rewardToken.address, addr)
+      )
+
+      logVaultAprDebug({
+        stage: 'token_filter',
+        vaultAddress,
+        vaultName,
+        poolType,
+        opportunityIdentifier: opportunity.identifier,
+        campaignId,
+        rewardTokenAddress: campaign.rewardToken.address,
+        rewardTokenSymbol: campaign.rewardToken.symbol,
+        tokenMatched: tokenMatches,
+        aprValue: aprBreakdown.value,
+        reason: tokenMatches ? 'reward_token_allowed' : 'reward_token_filtered',
+      })
+
+      if (tokenMatches) {
+        vaultAprValues.push({ apr: aprBreakdown.value, campaign })
       }
     }
-
-    log('═'.repeat(50))
   }
-  log(
-    `📋 Summary: Found ${
-      vaultAprValues.length
-    } campaigns with APR data for vault ${shortenAddress(vaultAddress)}\n`
-  )
 
   // Return all APR breakdowns for each matching campaign
   const tokenBreakdowns: YearnRewardCalculatorResult[] = vaultAprValues.map(
@@ -303,7 +328,23 @@ export const calculateYearnVaultRewardsAPR = (
     })
   )
 
-  return combineTokenBreakdowns(tokenBreakdowns, 'vaultAddress')
+  const combined = combineTokenBreakdowns(tokenBreakdowns, 'vaultAddress')
+  logVaultAprDebug({
+    stage: 'result_summary',
+    vaultAddress,
+    vaultName,
+    poolType,
+    opportunityIdentifier: opportunity.identifier,
+    campaignsTotal: opportunity.campaigns.length,
+    aprBreakdownsTotal: aprBreakdowns.length,
+    acceptedCampaigns: combined.length,
+    reason:
+      combined.length > 0
+        ? 'apr_calculated'
+        : 'no_matching_campaigns_after_filters',
+  })
+
+  return combined
 }
 
 /**

--- a/src/app/services/aprCalcs/yearnAprCalculator.ts
+++ b/src/app/services/aprCalcs/yearnAprCalculator.ts
@@ -47,8 +47,7 @@ export class YearnAprCalculator implements APRCalculator {
         vault.address,
         yearnOpportunities,
         'yearn',
-        WRAPPED_KAT_ADDRESSES,
-        true // Enable logging for debugging
+        WRAPPED_KAT_ADDRESSES
       )
       return [vault.address, vaultResults]
     })

--- a/src/app/services/dataCache.test.ts
+++ b/src/app/services/dataCache.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { YearnVault } from '../types'
+
+const mocks = vi.hoisted(() => ({
+  mockGetVaults: vi.fn(),
+  mockCalculateVaultAPRs: vi.fn(),
+  mockCalculateSteerPoints: vi.fn(),
+  logVaultAprDebug: vi.fn(),
+}))
+
+vi.mock('./externalApis/yearnApi', () => ({
+  YearnApiService: vi.fn().mockImplementation(() => ({
+    getVaults: mocks.mockGetVaults,
+  })),
+}))
+
+vi.mock('./aprCalcs/yearnAprCalculator', () => ({
+  YearnAprCalculator: vi.fn().mockImplementation(() => ({
+    calculateVaultAPRs: mocks.mockCalculateVaultAPRs,
+  })),
+}))
+
+vi.mock('./pointsCalcs/steerPointsCalculator', () => ({
+  SteerPointsCalculator: vi.fn().mockImplementation(() => ({
+    calculateForVault: mocks.mockCalculateSteerPoints,
+  })),
+}))
+
+vi.mock('./aprCalcs/debugLogger', () => ({
+  logVaultAprDebug: mocks.logVaultAprDebug,
+}))
+
+import { DataCacheService } from './dataCache'
+
+const makeVault = (): YearnVault => ({
+  address: '0x00000000000000000000000000000000000000aa',
+  symbol: 'TST',
+  name: 'Test Vault',
+  chainID: 747474,
+  strategies: [],
+  apr: {
+    netAPR: 0.02,
+  },
+})
+
+describe('DataCacheService.generateVaultAPRData', () => {
+  beforeEach(() => {
+    mocks.mockGetVaults.mockReset()
+    mocks.mockCalculateVaultAPRs.mockReset()
+    mocks.mockCalculateSteerPoints.mockReset()
+    mocks.logVaultAprDebug.mockReset()
+    mocks.mockCalculateSteerPoints.mockReturnValue(0)
+  })
+
+  it('returns fallback payload when all calculator results are empty', async () => {
+    const vault = makeVault()
+    mocks.mockGetVaults.mockResolvedValue([vault])
+    mocks.mockCalculateVaultAPRs.mockResolvedValue({
+      [vault.address]: [],
+    })
+
+    const service = new DataCacheService()
+    const data = await service.generateVaultAPRData()
+
+    expect(data[vault.address]).toEqual({
+      name: vault.name,
+      apr: 0,
+      pools: undefined,
+      breakdown: [],
+    })
+    expect(mocks.logVaultAprDebug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: 'fallback',
+        vaultAddress: vault.address,
+        reason: 'empty_results_after_calculation',
+      }),
+    )
+  })
+
+  it('aggregates vault APR when rewards data exists', async () => {
+    const vault = makeVault()
+    mocks.mockGetVaults.mockResolvedValue([vault])
+    mocks.mockCalculateVaultAPRs.mockResolvedValue({
+      [vault.address]: [
+        {
+          vaultName: vault.name,
+          vaultAddress: vault.address,
+          poolType: 'yearn',
+          breakdown: {
+            apr: 10,
+            token: {
+              address: '0x00000000000000000000000000000000000000bb',
+              symbol: 'KAT',
+              decimals: 18,
+            },
+            weight: 0,
+          },
+        },
+      ],
+    })
+
+    const service = new DataCacheService()
+    const data = await service.generateVaultAPRData()
+    const aggregatedVault = data[vault.address]
+
+    expect(aggregatedVault.address).toBe(vault.address)
+    expect(aggregatedVault.apr?.extra?.katanaAppRewardsAPR).toBe(0.1)
+    expect(mocks.logVaultAprDebug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: 'result_summary',
+        vaultAddress: vault.address,
+        reason: 'vault_results_aggregated',
+      }),
+    )
+  })
+})

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -5,6 +5,7 @@ import type { YearnVault } from '../types/index'
 import { YearnApiService } from './externalApis/yearnApi'
 import { YearnAprCalculator } from './aprCalcs/yearnAprCalculator'
 import { SteerPointsCalculator } from './pointsCalcs/steerPointsCalculator'
+import { logVaultAprDebug } from './aprCalcs/debugLogger'
 import {
   type RewardCalculatorResult,
   TokenBreakdown,
@@ -108,6 +109,13 @@ export class DataCacheService {
             .value()
 
           if (allResults.length === 0) {
+            logVaultAprDebug({
+              stage: 'fallback',
+              vaultAddress: vault.address,
+              vaultName: vault.name,
+              vaultSymbol: vault.symbol,
+              reason: 'empty_results_after_calculation',
+            })
             return [
               vault.address,
               {
@@ -119,9 +127,25 @@ export class DataCacheService {
             ]
           }
 
+          logVaultAprDebug({
+            stage: 'result_summary',
+            vaultAddress: vault.address,
+            vaultName: vault.name,
+            vaultSymbol: vault.symbol,
+            acceptedCampaigns: allResults.length,
+            reason: 'vault_results_aggregated',
+          })
+
           return [vault.address, this.aggregateVaultResults(vault, allResults)]
         } catch (error) {
           console.error(`Error processing vault ${vault.address}:`, error)
+          logVaultAprDebug({
+            stage: 'fallback',
+            vaultAddress: vault.address,
+            vaultName: vault.name,
+            vaultSymbol: vault.symbol,
+            reason: 'exception_while_processing_vault',
+          })
           return [
             vault.address,
             {

--- a/src/app/services/externalApis/merklApi.test.ts
+++ b/src/app/services/externalApis/merklApi.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  axiosGet: vi.fn(),
+  logVaultAprDebug: vi.fn(),
+}))
+
+vi.mock('axios', () => ({
+  default: {
+    get: mocks.axiosGet,
+  },
+}))
+
+vi.mock('../aprCalcs/debugLogger', () => ({
+  logVaultAprDebug: mocks.logVaultAprDebug,
+}))
+
+import { MerklApiService } from './merklApi'
+
+describe('MerklApiService', () => {
+  beforeEach(() => {
+    mocks.axiosGet.mockReset()
+    mocks.logVaultAprDebug.mockReset()
+  })
+
+  it('logs when a blacklist removes the active APR-breakdown campaign', async () => {
+    const vaultAddress = '0x93Fec6639717b6215A48E5a72a162C50DCC40d68'
+    const blacklistedCampaignId =
+      '0xc5a22d022154d5c64ff14b2f4071f134eb83cf159f9f846ad0ba0908a755e86d'
+
+    mocks.axiosGet.mockResolvedValue({
+      data: [
+        {
+          chainId: 747474,
+          name: 'AUSD Opportunity',
+          tvl: 1_000_000,
+          status: 'LIVE',
+          identifier: vaultAddress,
+          campaigns: [
+            {
+              campaignId: blacklistedCampaignId,
+              amount: '1',
+              rewardToken: {
+                address: '0x6E9C1F88a960fE63387eb4b71BC525a9313d8461',
+                symbol: 'KAT',
+                decimals: 18,
+                price: 1,
+              },
+              startTimestamp: 0,
+              endTimestamp: 0,
+            },
+            {
+              campaignId:
+                '0x1111111111111111111111111111111111111111111111111111111111111111',
+              amount: '1',
+              rewardToken: {
+                address: '0x6E9C1F88a960fE63387eb4b71BC525a9313d8461',
+                symbol: 'KAT',
+                decimals: 18,
+                price: 1,
+              },
+              startTimestamp: 0,
+              endTimestamp: 0,
+            },
+          ],
+          aprRecord: {
+            breakdowns: [
+              {
+                identifier: blacklistedCampaignId,
+                value: 12.3,
+              },
+            ],
+          },
+        },
+      ],
+    })
+
+    const service = new MerklApiService()
+    const opportunities = await service.getErc20LogProcessorOpportunities()
+
+    expect(opportunities).toHaveLength(1)
+    expect(opportunities[0].campaigns).toHaveLength(1)
+    expect(opportunities[0].campaigns?.[0]?.campaignId).not.toBe(
+      blacklistedCampaignId,
+    )
+
+    expect(mocks.logVaultAprDebug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: 'blacklist_filter',
+        vaultAddress,
+        reason: 'apr_breakdown_campaign_blacklisted',
+        blacklistedCampaigns: 1,
+        blacklistedCampaignIds: [blacklistedCampaignId],
+        blacklistedAprBreakdownCampaignIds: [blacklistedCampaignId],
+      }),
+    )
+  })
+})

--- a/src/app/services/externalApis/merklApi.ts
+++ b/src/app/services/externalApis/merklApi.ts
@@ -3,11 +3,7 @@ import { config } from '../../config'
 import type { MerklOpportunity } from '../../types'
 import { isAddress } from 'viem'
 import { logVaultAprDebug } from '../aprCalcs/debugLogger'
-
-const EXCLUDED_CAMPAIGN_IDS = new Set([
-  '0x487022e5f413f60e3e6aa251712f9c2d6601f01d14b565e779a61b68c173bd6c',
-  '0xc5a22d022154d5c64ff14b2f4071f134eb83cf159f9f846ad0ba0908a755e86d',
-])
+import { isExcludedCampaignId } from './merklBlacklist'
 
 const extractAddressFromIdentifier = (
   identifier?: string
@@ -38,9 +34,11 @@ export class MerklApiService {
       const removedCampaignIds: string[] = []
       const filteredCampaigns = opportunity.campaigns.filter((campaign) => {
         const campaignId = campaign.campaignId?.toLowerCase()
-        const isExcluded = !!campaignId && EXCLUDED_CAMPAIGN_IDS.has(campaignId)
+        const isExcluded = isExcludedCampaignId(campaign.campaignId)
         if (isExcluded) {
-          removedCampaignIds.push(campaignId)
+          if (campaignId) {
+            removedCampaignIds.push(campaignId)
+          }
         }
         return !isExcluded
       })

--- a/src/app/services/externalApis/merklApi.ts
+++ b/src/app/services/externalApis/merklApi.ts
@@ -1,11 +1,24 @@
 import axios from 'axios'
 import { config } from '../../config'
 import type { MerklOpportunity } from '../../types'
+import { isAddress } from 'viem'
+import { logVaultAprDebug } from '../aprCalcs/debugLogger'
 
 const EXCLUDED_CAMPAIGN_IDS = new Set([
   '0x487022e5f413f60e3e6aa251712f9c2d6601f01d14b565e779a61b68c173bd6c',
   '0xc5a22d022154d5c64ff14b2f4071f134eb83cf159f9f846ad0ba0908a755e86d',
 ])
+
+const extractAddressFromIdentifier = (
+  identifier?: string
+): string | undefined => {
+  if (!identifier) {
+    return undefined
+  }
+
+  const candidate = identifier.slice(0, 42)
+  return isAddress(candidate) ? candidate : undefined
+}
 
 export class MerklApiService {
   private apiUrl: string
@@ -156,7 +169,28 @@ export class MerklApiService {
         ? response.data
         : response.data.opportunities || []
 
-      return this.filterCampaigns(opportunities)
+      const filteredOpportunities = this.filterCampaigns(opportunities)
+      for (const opportunity of filteredOpportunities) {
+        const vaultAddress = extractAddressFromIdentifier(
+          opportunity.identifier
+        )
+        if (!vaultAddress) {
+          continue
+        }
+
+        logVaultAprDebug({
+          stage: 'opportunity_fetch',
+          vaultAddress,
+          poolType: 'yearn',
+          opportunityType: 'ERC20LOGPROCESSOR',
+          opportunityIdentifier: opportunity.identifier,
+          opportunitiesTotal: filteredOpportunities.length,
+          campaignsTotal: opportunity.campaigns?.length || 0,
+          reason: 'merkl_opportunity_loaded',
+        })
+      }
+
+      return filteredOpportunities
     } catch (error) {
       console.error('Error fetching ERC20 Log Processor opportunities:', error)
       return []
@@ -193,7 +227,28 @@ export class MerklApiService {
         ? response.data
         : response.data.opportunities || []
 
-      return this.filterCampaigns(opportunities)
+      const filteredOpportunities = this.filterCampaigns(opportunities)
+      for (const opportunity of filteredOpportunities) {
+        const vaultAddress = extractAddressFromIdentifier(
+          opportunity.identifier
+        )
+        if (!vaultAddress) {
+          continue
+        }
+
+        logVaultAprDebug({
+          stage: 'opportunity_fetch',
+          vaultAddress,
+          poolType: 'fixed rate',
+          opportunityType: 'ERC20_FIX_APR',
+          opportunityIdentifier: opportunity.identifier,
+          opportunitiesTotal: filteredOpportunities.length,
+          campaignsTotal: opportunity.campaigns?.length || 0,
+          reason: 'merkl_opportunity_loaded',
+        })
+      }
+
+      return filteredOpportunities
     } catch (error) {
       console.error('Error fetching ERC20 Log Processor opportunities:', error)
       return []

--- a/src/app/services/externalApis/merklBlacklist.test.ts
+++ b/src/app/services/externalApis/merklBlacklist.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EXCLUDED_CAMPAIGN_IDS,
+  isExcludedCampaignId,
+} from './merklBlacklist'
+
+describe('merklBlacklist', () => {
+  it('matches excluded campaign IDs case-insensitively', () => {
+    const [firstCampaignId] = Array.from(EXCLUDED_CAMPAIGN_IDS)
+    expect(firstCampaignId).toBeDefined()
+
+    if (!firstCampaignId) {
+      throw new Error('Expected at least one excluded campaign ID')
+    }
+
+    expect(isExcludedCampaignId(firstCampaignId)).toBe(true)
+    expect(isExcludedCampaignId(firstCampaignId.toUpperCase())).toBe(true)
+  })
+
+  it('returns false for unknown or missing campaign IDs', () => {
+    expect(
+      isExcludedCampaignId(
+        '0x1111111111111111111111111111111111111111111111111111111111111111'
+      )
+    ).toBe(false)
+    expect(isExcludedCampaignId(undefined)).toBe(false)
+  })
+})

--- a/src/app/services/externalApis/merklBlacklist.ts
+++ b/src/app/services/externalApis/merklBlacklist.ts
@@ -1,0 +1,12 @@
+export const EXCLUDED_CAMPAIGN_IDS = new Set([
+  '0x487022e5f413f60e3e6aa251712f9c2d6601f01d14b565e779a61b68c173bd6c',
+  '0xc5a22d022154d5c64ff14b2f4071f134eb83cf159f9f846ad0ba0908a755e86d',
+])
+
+export const isExcludedCampaignId = (campaignId?: string): boolean => {
+  if (!campaignId) {
+    return false
+  }
+
+  return EXCLUDED_CAMPAIGN_IDS.has(campaignId.toLowerCase())
+}

--- a/src/app/services/externalApis/yearnApi.ts
+++ b/src/app/services/externalApis/yearnApi.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import { config } from '../../config'
 import type { YearnVault } from '../../types'
+import { logVaultAprDebug } from '../aprCalcs/debugLogger'
 
 export class YearnApiService {
   private apiUrl: string
@@ -27,6 +28,18 @@ export class YearnApiService {
 
       const response = await axios.get<YearnVault[]>(url)
       const vaults: YearnVault[] = response.data || []
+
+      for (const vault of vaults) {
+        logVaultAprDebug({
+          stage: 'vault_fetch',
+          vaultAddress: vault.address,
+          vaultName: vault.name,
+          vaultSymbol: vault.symbol,
+          chainId,
+          totalVaults: vaults.length,
+          reason: 'fetched_from_ydaemon',
+        })
+      }
 
       return vaults
     } catch (error) {

--- a/src/app/types/merkl.ts
+++ b/src/app/types/merkl.ts
@@ -17,6 +17,12 @@ export interface MerklOpportunity {
   chainId: number
   name: string
   apr?: number
+  aprRecord?: {
+    breakdowns?: Array<{
+      identifier?: string
+      value?: number
+    }>
+  }
   tags?: string[]
   tvl: number
   address?: string


### PR DESCRIPTION
## Summary

  This PR fixes a fallback-path bug where some vaults (including AUSD) could return an incomplete fallback payload (apr: 0, breakdown: []) instead of a fully aggregated vault response. It also adds a
  reusable APR debugging workflow (logs + CLI + tests) to diagnose similar issues across all vaults.



  When a vault had an opportunity but no campaigns surviving APR/token filters (including blacklist filtering), calculateYearnVaultRewardsAPR could return an empty array. That empty result propagated
  to the cache layer and triggered a generic fallback object, which bypassed the normal aggregation behavior.

  ### What changed

  - Updated Yearn reward APR calculation to return a zero placeholder reward result instead of [] in non-match cases:
      - no opportunity
      - opportunity with no campaigns
      - no APR breakdown match
      - token filtered out
      - no matching campaigns after filters
  - This keeps vaults in the normal aggregation path so responses are complete, while APR contribution remains 0 where appropriate.
  - Kept null only for invalid input cases (e.g. missing vault address).
  - Added type narrowing around APR breakdown values to avoid number | undefined build-time issues.

  ## Debugging Improvements
  - Added gated APR debug config:
      - APR_DEBUG_VAULT_ADDRESS
  - Added readable, stage-based APR debug logging across the pipeline:
      - vault fetch
      - opportunity fetch/lookup
      - campaign scan + APR match
      - token filter
      - result summary
      - blacklist filtering
  - Added a live debug CLI script: bun run test:vault-debug:live
      - Supports --vault and --all --limit
      - Now applies the same Merkl campaign blacklist logic as production


  Added/updated tests for:

  - APR calculation fallback behavior
  - Data cache fallback vs aggregation behavior
  - Debug logger gating/filtering/sampling
  - API route response handling
  - Merkl blacklist filtering/logging
  - Shared blacklist helper behavior

  Validation run:

  - bun run test:run passed
  - bun run lint passed (existing no-explicit-any warning remains)
  - bun run build passed

  ## Notes

  - Includes debug documentation in docs/vault-apr-debug.md.
  - Includes a shared Merkl blacklist helper to keep production and debug tooling behavior aligned.