### PR TITLE
Fix Next.js build by removing unnecessary exports from webhook route

### DIFF
--- a/src/app/api/webhook/route.ts
+++ b/src/app/api/webhook/route.ts
@@ -14,7 +14,7 @@ const COMPONENTS: (keyof YearnVaultExtra)[] = [
   'steerPointsPerDollar',
 ]
 
-export interface KongOutput {
+interface KongOutput {
   chainId: number
   address: string
   label: string
@@ -24,7 +24,7 @@ export interface KongOutput {
   blockTime: bigint
 }
 
-export interface ParsedWebhookBody {
+interface ParsedWebhookBody {
   addresses: string[]
   chainId: number
   blockNumber: bigint
@@ -32,7 +32,7 @@ export interface ParsedWebhookBody {
   label: string
 }
 
-export function verifyWebhookSignature(
+function verifyWebhookSignature(
   signatureHeader: string,
   body: string,
   secret: string,
@@ -64,7 +64,7 @@ export function verifyWebhookSignature(
   }
 }
 
-export function parseWebhookBody(rawBody: string): ParsedWebhookBody {
+function parseWebhookBody(rawBody: string): ParsedWebhookBody {
   const body = JSON.parse(rawBody)
   const { vaults, chainId, blockNumber, blockTime, subscription } = body
   return {
@@ -76,7 +76,7 @@ export function parseWebhookBody(rawBody: string): ParsedWebhookBody {
   }
 }
 
-export function jsonResponseWithBigInt(data: unknown): Response {
+function jsonResponseWithBigInt(data: unknown): Response {
   const replacer = (_: string, v: unknown) =>
     typeof v === 'bigint' ? v.toString() : v
   return new Response(JSON.stringify(data, replacer), {


### PR DESCRIPTION
### Summary
Remove unnecessary `export` keywords from internal interfaces and helper functions in `src/app/api/webhook/route.ts`. Next.js App Router only expects HTTP method handlers (e.g. `POST`) to be exported from route files — exporting internal types and utilities can cause build errors.

### How to review
Single file change (`src/app/api/webhook/route.ts`). All modifications are simply removing the `export` keyword from:
- `KongOutput` interface
- `ParsedWebhookBody` interface
- `verifyWebhookSignature` function
- `parseWebhookBody` function
- `jsonResponseWithBigInt` function

None of these are imported elsewhere — they are only used within the route file.

### Test plan
- [ ] Manual: Run `npm run build` and confirm the build completes without errors
- [ ] Manual: Send a test webhook request to `/api/webhook` and verify it still processes correctly

### Risk / impact
Low risk. No behavioral changes — only visibility modifiers removed. These symbols are not imported by any other module.