### PR TITLE
fix: remove wrong apy/apr indicators from webohook

### DIFF
--- a/src/app/api/webhook/route.ts
+++ b/src/app/api/webhook/route.ts
@@ -123,13 +123,6 @@ export async function POST(req: NextRequest): Promise<Response> {
       for (const component of COMPONENTS) {
         outputs.push({ ...base, component, value: extra[component] ?? 0 })
       }
-
-      const netAPR = vault.apr?.netAPR ?? 0
-      const profitUnlockPeriods = 365 / 7
-      const netAPY = (1 + netAPR / profitUnlockPeriods) ** profitUnlockPeriods - 1
-
-      outputs.push({ ...base, component: 'netAPR', value: netAPR })
-      outputs.push({ ...base, component: 'netAPY', value: netAPY })
     }
 
     return jsonResponseWithBigInt(outputs)


### PR DESCRIPTION
## Summary
Apy and apr on katana represents historical values, not forward like indicators which can lead to confusion, so removing to return undefined for kong.



## Test plan

- [ ] Copy `.env.example` to `.env.local` and fill in required values
```bash
cp .env.example .env.local
# Edit .env.local and set:
#   RPC_URL_KATANA=<your-katana-rpc-url>
#   KONG_WEBHOOK_SECRET=<your-secret>
```

- [ ] Install dependencies and start the dev server
```bash
npm install && npm run dev
```

- [ ] Generate a valid webhook signature and send a test request - or comment the kong signature+secret validation locally for test
```bash
# Set these to match your .env.local
SECRET="<your-KONG_WEBHOOK_SECRET>"
TIMESTAMP=$(date +%s)

BODY='{"abiPath":"yearn/3/vault","chainId":747474,"blockNumber":"21500000","blockTime":"1735000000","subscription":{"id":"S_KATANA_APR","url":"https://katana-apr.yearn.fi/api/webhook","abiPath":"yearn/3/vault","type":"timeseries","labels":["katana-estimated-apr"],"filter":{"contracts":[{"chainId":747474,"address":"0x80c34BD3A3569E126e7055831036aa7b212cB159"}]}},"vaults":["0x80c34BD3A3569E126e7055831036aa7b212cB159"]}'

SIGNATURE=$(echo -n "${TIMESTAMP}.${BODY}" | openssl dgst -sha256 -hmac "${SECRET}" | awk '{print $2}')

curl -s -X POST 'http://localhost:3000/api/webhook' \
  -H 'Content-Type: application/json' \
  -H "Kong-Signature: t=${TIMESTAMP},v1=${SIGNATURE}" \
  -d "${BODY}" | jq .
  
  
unset $SECRET
```
Expected: JSON array with objects containing `component` and `value` fields - without the presence of netApy or netAPR