### PR TITLE
Codex/app reward troubleshooting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # Repository Guidelines
 
+## Start Here
+
+- `docs/api-integration-guide.md` (primary reference for API flow, Merkl/yDaemon queries, filters, and live examples)
+
 ## Project Structure & Module Organization
 
 Core application code lives in `src/app`, using the Next.js App Router. API handlers sit under `src/app/api`, while shared DTOs and helper types reside in `src/app/types`. Business logic is grouped by concern within `src/app/services` (`aprCalcs`, `pointsCalcs`, `externalApis`, caching utilities), so keep new computations alongside their peers. Configuration helpers stay in `src/app/config`, and example payloads for the marketing surface belong in `src/app/quick-apys`. Static assets (favicons, images) should be added to `public`, not embedded in source files.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This is a Next.js app that provides APR and points data for Yearn vaults on Katana via API endpoints. It is designed for serverless deployment (e.g., Vercel).
 
+## Start Here
+
+For a full explanation of how this service queries yDaemon and Merkl, how values are filtered, and why vault rewards may resolve to zero, read:
+
+- [`docs/api-integration-guide.md`](./docs/api-integration-guide.md)
+
 ## Getting Started
 
 Start the development server:

--- a/docs/api-integration-guide.md
+++ b/docs/api-integration-guide.md
@@ -1,0 +1,373 @@
+# API Integration Guide (Start Here)
+
+This is the primary reference for how this repository collects, filters, and serves APR data.
+
+If you are debugging rewards, adding new vault types, or validating Merkl behavior, start here before reading individual source files.
+
+## What This Service Does
+
+At request time, the service:
+
+1. Fetches Katana vaults from yDaemon.
+2. Fetches live `ERC20LOGPROCESSOR` opportunities from Merkl (with campaigns).
+3. Filters Merkl campaigns with a local blacklist.
+4. Matches each vault to a Merkl opportunity.
+5. Keeps only campaigns that:
+   - have an APR breakdown entry, and
+   - pay allowlisted KAT token addresses.
+6. Aggregates APR and appends `apr.extra` fields.
+7. Returns vault data from `GET /api/vaults`.
+
+## Code Map
+
+- API routes:
+  - `src/app/api/vaults/route.ts`
+  - `src/app/api/webhook/route.ts`
+  - `src/app/api/health/route.ts`
+- Orchestration and aggregation:
+  - `src/app/services/dataCache.ts`
+- External APIs:
+  - `src/app/services/externalApis/yearnApi.ts`
+  - `src/app/services/externalApis/merklApi.ts`
+  - `src/app/services/externalApis/merklBlacklist.ts`
+- APR matching logic:
+  - `src/app/services/aprCalcs/yearnAprCalculator.ts`
+  - `src/app/services/aprCalcs/utils.ts`
+- Points logic:
+  - `src/app/services/pointsCalcs/steerPointsCalculator.ts`
+
+## External APIs Queried
+
+### yDaemon (vault universe)
+
+Base URL (default):
+
+- `https://ydaemon.yearn.fi`
+
+Endpoint used by this repo:
+
+- `GET /vaults/katana`
+
+Query params used:
+
+- `hideAlways=true`
+- `orderBy=featuringScore`
+- `orderDirection=desc`
+- `strategiesDetails=withDetails`
+- `strategiesCondition=inQueue`
+- `chainIDs=747474`
+- `limit=2500`
+
+Example:
+
+```bash
+curl -sS 'https://ydaemon.yearn.fi/vaults/katana?hideAlways=true&orderBy=featuringScore&orderDirection=desc&strategiesDetails=withDetails&strategiesCondition=inQueue&chainIDs=747474&limit=2500'
+```
+
+### Merkl (opportunities and campaigns)
+
+Base URL (default):
+
+- `https://api.merkl.xyz`
+
+Docs:
+
+- HTML docs: `https://api.merkl.xyz/docs#tag/opportunities`
+- OpenAPI JSON: `https://api.merkl.xyz/docs/json`
+
+Main endpoint used by this repo:
+
+- `GET /v4/opportunities` (works with or without trailing slash)
+
+Primary params used in app code:
+
+- `status=LIVE`
+- `chainId=747474`
+- `type=ERC20LOGPROCESSOR`
+- `campaigns=true`
+
+Useful documented filters for debugging:
+
+- `identifier=<vaultAddress>`
+- `campaignId=<onchainCampaignId>`
+- `tags=<tag>`
+- `mainProtocolId=<protocolId>`
+
+Examples:
+
+```bash
+# Core query used by this service
+curl -sS 'https://api.merkl.xyz/v4/opportunities?chainId=747474&type=ERC20LOGPROCESSOR&status=LIVE&campaigns=true'
+
+# Find one opportunity by identifier (vault address)
+curl -sS 'https://api.merkl.xyz/v4/opportunities/?chainId=747474&type=ERC20LOGPROCESSOR&status=LIVE&campaigns=true&identifier=0x80c34BD3A3569E126e7055831036aa7b212cB159'
+
+# Find opportunities containing a specific campaign
+curl -sS 'https://api.merkl.xyz/v4/opportunities/?chainId=747474&type=ERC20LOGPROCESSOR&status=LIVE&campaigns=true&campaignId=0xc5a22d022154d5c64ff14b2f4071f134eb83cf159f9f846ad0ba0908a755e86d'
+```
+
+## End-to-End Pipeline
+
+### 1) Vault fetch
+
+`YearnApiService.getVaults()` fetches the Katana vault list from yDaemon.
+
+### 2) Merkl fetch
+
+`MerklApiService.getErc20LogProcessorOpportunities()` fetches Merkl opportunities and campaign payloads.
+
+### 3) Blacklist filter
+
+`MerklApiService.filterCampaigns()` removes campaign IDs in:
+
+- `src/app/services/externalApis/merklBlacklist.ts`
+
+Current excluded IDs:
+
+- `0x487022e5f413f60e3e6aa251712f9c2d6601f01d14b565e779a61b68c173bd6c`
+- `0xc5a22d022154d5c64ff14b2f4071f134eb83cf159f9f846ad0ba0908a755e86d`
+
+### 4) Opportunity selection per vault
+
+`calculateYearnVaultRewardsAPR()` uses `findBestOpportunityByAddress()`:
+
+- Match candidates where `identifier == vaultAddress` or starts with `vaultAddress`.
+- Prefer exact identifier matches.
+- Prefer opportunities with campaigns/APR breakdown data.
+
+This avoids selecting suffix variants like `0x...JUMPER` when a better exact match exists.
+
+### 5) Campaign/APR match
+
+For each campaign in the chosen opportunity:
+
+- Campaign must have a matching APR breakdown:
+  - `campaign.campaignId` equals `aprRecord.breakdowns[].identifier`
+- Campaign reward token must be allowlisted in `WRAPPED_KAT_ADDRESSES`:
+  - `0x6E9C1F88a960fE63387eb4b71BC525a9313d8461`
+  - `0x3ba1fbC4c3aEA775d335b31fb53778f46FD3a330`
+  - `0x0161A31702d6CF715aaa912d64c6A190FD0093aa`
+
+APR units:
+
+- Merkl `breakdown.value` is a percent value (for example `0.56` means `0.56%`).
+- Service converts to decimal by dividing by `100` before storing in `apr.extra.katanaAppRewardsAPR`.
+
+### 6) Final vault output shaping
+
+`DataCacheService.aggregateVaultResults()` sets:
+
+- `apr.extra.katanaRewardsAPR` (legacy alias)
+- `apr.extra.katanaAppRewardsAPR`
+- `apr.extra.fixedRateKatanaRewards` (currently hardcoded table)
+- `apr.extra.katanaBonusAPY` (hardcoded table)
+- `apr.extra.katanaNativeYield` (`vault.apr.netAPR`)
+- `apr.extra.steerPointsPerDollar` (from strategy debt-weighted rates)
+
+## Why a Vault Can Show `katanaAppRewardsAPR = 0`
+
+Most common reasons:
+
+1. No Merkl opportunity matches the vault address.
+2. Opportunity exists but has no campaigns.
+3. Campaigns exist but none match APR breakdown identifiers.
+4. Matching campaigns exist but reward token is not allowlisted.
+5. Matching campaign was removed by local blacklist.
+
+Debug tool:
+
+```bash
+bun run test:vault-debug:live -- --vault <0xVaultAddress>
+```
+
+Related doc:
+
+- `docs/vault-apr-debug.md`
+
+## Live Example Snapshots
+
+These were sampled from live upstream APIs on **March 9, 2026 (America/New_York)** and can change over time.
+
+### 1) yDaemon vault sample (USDC yVault)
+
+Query:
+
+```bash
+curl -sS 'https://ydaemon.yearn.fi/vaults/katana?hideAlways=true&orderBy=featuringScore&orderDirection=desc&strategiesDetails=withDetails&strategiesCondition=inQueue&chainIDs=747474&limit=2500'
+```
+
+Snippet:
+
+```json
+{
+  "address": "0x80c34BD3A3569E126e7055831036aa7b212cB159",
+  "symbol": "yvvbUSDC",
+  "name": "USDC yVault",
+  "netAPR": 0.03392437419763983,
+  "strategiesCount": 6
+}
+```
+
+### 2) Merkl by identifier (USDC yVault)
+
+Query:
+
+```bash
+curl -sS 'https://api.merkl.xyz/v4/opportunities/?chainId=747474&type=ERC20LOGPROCESSOR&status=LIVE&campaigns=true&identifier=0x80c34BD3A3569E126e7055831036aa7b212cB159'
+```
+
+Snippet:
+
+```json
+{
+  "identifier": "0x80c34BD3A3569E126e7055831036aa7b212cB159",
+  "tags": ["yearn"],
+  "protocol": "yearn",
+  "campaignCount": 197,
+  "aprBreakdowns": [
+    { "id": "1741685296625366069", "val": 0.2235032230390019 },
+    { "id": "3105973045068130992", "val": 0.03591900439958706 },
+    { "id": "367677271763782079", "val": 0.3066217926257951 }
+  ],
+  "apr": 0.5660440200643841
+}
+```
+
+### 3) Merkl by identifier (Morpho-tagged `0x78EC...`)
+
+Query:
+
+```bash
+curl -sS 'https://api.merkl.xyz/v4/opportunities/?chainId=747474&type=ERC20LOGPROCESSOR&status=LIVE&campaigns=true&identifier=0x78EC25FBa1bAf6b7dc097Ebb8115A390A2a4Ee12'
+```
+
+Snippet:
+
+```json
+{
+  "identifier": "0x78EC25FBa1bAf6b7dc097Ebb8115A390A2a4Ee12",
+  "name": "Hold ysvbUSDC",
+  "tags": ["morpho"],
+  "protocol": null,
+  "campaignCount": 12,
+  "aprBreakdowns": [
+    { "id": "5698558020446595008", "val": 0.7495762369774704 }
+  ],
+  "firstRewardToken": {
+    "address": "0x3ba1fbC4c3aEA775d335b31fb53778f46FD3a330",
+    "symbol": "KAT"
+  },
+  "apr": 0.7495762369774704
+}
+```
+
+### 4) Merkl by campaignId (AUSD blacklisted campaign)
+
+Query:
+
+```bash
+curl -sS 'https://api.merkl.xyz/v4/opportunities/?chainId=747474&type=ERC20LOGPROCESSOR&status=LIVE&campaigns=true&campaignId=0xc5a22d022154d5c64ff14b2f4071f134eb83cf159f9f846ad0ba0908a755e86d'
+```
+
+Snippet:
+
+```json
+{
+  "identifier": "0x93Fec6639717b6215A48E5a72a162C50DCC40d68",
+  "name": "Deposit AUSD in AUSD yVault",
+  "tags": ["sushiswap"],
+  "aprBreakdownIds": [
+    "0xc5a22d022154d5c64ff14b2f4071f134eb83cf159f9f846ad0ba0908a755e86d"
+  ],
+  "matchingCampaign": {
+    "campaignId": "0xc5a22d022154d5c64ff14b2f4071f134eb83cf159f9f846ad0ba0908a755e86d",
+    "rewardToken": {
+      "address": "0x6E9C1F88a960fE63387eb4b71BC525a9313d8461",
+      "symbol": "KAT"
+    },
+    "dailyRewards": 577.3809523809524,
+    "apr": 22.05570796360016
+  }
+}
+```
+
+### 5) Service output snapshot (computed extras)
+
+From `DataCacheService.generateVaultAPRData()`:
+
+```json
+[
+  {
+    "address": "0x80c34BD3A3569E126e7055831036aa7b212cB159",
+    "symbol": "yvvbUSDC",
+    "name": "USDC yVault",
+    "katanaAppRewardsAPR": 0.005709245156139802,
+    "fixedRateKatanaRewards": 0.35,
+    "katanaBonusAPY": 0.068,
+    "katanaNativeYield": 0.03392437419763983,
+    "steerPointsPerDollar": 0.1711
+  },
+  {
+    "address": "0x93Fec6639717b6215A48E5a72a162C50DCC40d68",
+    "symbol": "AUSD",
+    "name": "AUSD yVault",
+    "katanaAppRewardsAPR": 0,
+    "fixedRateKatanaRewards": 0.35,
+    "katanaBonusAPY": 0.068,
+    "katanaNativeYield": 0.11184248250750017,
+    "steerPointsPerDollar": 0.1294
+  },
+  {
+    "address": "0xAa0362eCC584B985056E47812931270b99C91f9d",
+    "symbol": "yvvbWBTC",
+    "name": "WBTC yVault",
+    "katanaAppRewardsAPR": 0,
+    "fixedRateKatanaRewards": 0.07,
+    "katanaBonusAPY": 0.016,
+    "katanaNativeYield": 0.0006326777539145123,
+    "steerPointsPerDollar": 0
+  }
+]
+```
+
+## Repository API Endpoints
+
+### `GET /api/vaults`
+
+- Regenerates vault APR data on each request.
+- Response is keyed by vault address.
+- Headers:
+  - `Access-Control-Allow-Origin: *`
+  - `Cache-Control: public, max-age=0, s-maxage=900, stale-while-revalidate=600`
+
+### `POST /api/webhook`
+
+- Verifies `kong-signature` HMAC (`KONG_WEBHOOK_SECRET`).
+- Accepts webhook body containing vault addresses.
+- Emits one row per requested vault per component:
+  - `katanaAppRewardsAPR`
+  - `fixedRateKatanaRewards`
+  - `katanaBonusAPY`
+  - `katanaNativeYield`
+  - `steerPointsPerDollar`
+
+### `GET /api/health`
+
+- Returns:
+
+```json
+{ "status": "ok", "timestamp": "<iso8601>" }
+```
+
+## Quick Troubleshooting Playbook
+
+When a vault looks wrong:
+
+1. Confirm vault exists in yDaemon query output.
+2. Query Merkl by `identifier=<vaultAddress>`.
+3. Check `aprRecord.breakdowns[].identifier`.
+4. Verify matching `campaigns[].campaignId` still exists after blacklist.
+5. Verify reward token is in `WRAPPED_KAT_ADDRESSES`.
+6. If multiple opportunities share an address prefix, ensure exact identifier match is chosen.
+7. Run the live debug script:
+   - `bun run test:vault-debug:live -- --vault <address>`

--- a/src/app/services/aprCalcs/utils.test.ts
+++ b/src/app/services/aprCalcs/utils.test.ts
@@ -241,4 +241,46 @@ describe('calculateYearnVaultRewardsAPR', () => {
       }),
     )
   })
+
+  it('prefers an exact identifier match over an earlier prefixed match', () => {
+    const results = calculateYearnVaultRewardsAPR(
+      'Vault',
+      VAULT_ADDRESS,
+      [
+        makeOpportunity({
+          identifier: `${VAULT_ADDRESS}JUMPER`,
+          campaigns: [],
+          aprRecord: { breakdowns: [] },
+        }),
+        makeOpportunity(),
+      ],
+      'yearn',
+      [WRAPPED_KAT_ADDRESS],
+    )
+
+    expect(results).toEqual([
+      {
+        vaultName: 'Vault',
+        vaultAddress: VAULT_ADDRESS,
+        poolType: 'yearn',
+        breakdown: {
+          apr: 12.5,
+          token: {
+            address: WRAPPED_KAT_ADDRESS,
+            symbol: 'KAT',
+            decimals: 18,
+          },
+          weight: 0,
+        },
+      },
+    ])
+
+    expect(mocks.logVaultAprDebug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: 'opportunity_lookup',
+        opportunityIdentifier: VAULT_ADDRESS,
+        reason: 'opportunity_found',
+      }),
+    )
+  })
 })

--- a/src/app/services/aprCalcs/utils.ts
+++ b/src/app/services/aprCalcs/utils.ts
@@ -50,6 +50,50 @@ const identifierMatchesAddress = (
   )
 }
 
+const identifierEqualsAddress = (
+  identifier?: string,
+  address?: string
+): boolean => {
+  if (!identifier || !address) {
+    return false
+  }
+  return identifier.toLowerCase() === address.toLowerCase()
+}
+
+const getCampaignCount = (opportunity: Opportunity): number =>
+  opportunity.campaigns?.length || 0
+
+const getAprBreakdownCount = (opportunity: Opportunity): number =>
+  Array.isArray(opportunity.aprRecord?.breakdowns)
+    ? opportunity.aprRecord.breakdowns.length
+    : 0
+
+const findBestOpportunityByAddress = (
+  opportunities: Opportunity[],
+  address: string
+): Opportunity | undefined => {
+  const matchingOpportunities = opportunities.filter((opp) =>
+    identifierMatchesAddress(opp.identifier, address)
+  )
+
+  if (matchingOpportunities.length === 0) {
+    return undefined
+  }
+
+  const exactMatches = matchingOpportunities.filter((opp) =>
+    identifierEqualsAddress(opp.identifier, address)
+  )
+
+  return (
+    exactMatches.find((opp) => getCampaignCount(opp) > 0) ||
+    exactMatches.find((opp) => getAprBreakdownCount(opp) > 0) ||
+    matchingOpportunities.find((opp) => getCampaignCount(opp) > 0) ||
+    matchingOpportunities.find((opp) => getAprBreakdownCount(opp) > 0) ||
+    exactMatches[0] ||
+    matchingOpportunities[0]
+  )
+}
+
 /**
  * Calculates the APR breakdown for a given strategy and pool, based on available opportunities and campaigns.
  *
@@ -76,9 +120,7 @@ export const calculateStrategyAPR = (
     return null
   }
 
-  const opportunity = opportunities.find((opp) =>
-    identifierMatchesAddress(opp.identifier, poolAddress)
-  )
+  const opportunity = findBestOpportunityByAddress(opportunities, poolAddress)
 
   if (!opportunity?.campaigns?.length) {
     console.log(
@@ -207,9 +249,7 @@ export const calculateYearnVaultRewardsAPR = (
     return null
   }
 
-  const opportunity = opportunities.find((opp) =>
-    identifierMatchesAddress(opp.identifier, vaultAddress)
-  )
+  const opportunity = findBestOpportunityByAddress(opportunities, vaultAddress)
 
   logVaultAprDebug({
     stage: 'opportunity_lookup',


### PR DESCRIPTION
## Summary
Fixes opportunity selection logic that could incorrectly choose a prefixed identifier (for example `0x...JUMPER`) instead of the exact vault/pool identifier, which caused valid rewards (notably USDC) to be missed.

Also adds additional documentation to the repo

## Problem
`calculateStrategyAPR` and `calculateYearnVaultRewardsAPR` previously used first-match lookup with prefix matching.
When multiple opportunities shared the same address prefix, the first match could be a less relevant entry (including one with no usable campaigns/APR breakdowns), resulting in zeroed rewards.

## What Changed

- Added smarter opportunity selection in `src/app/services/aprCalcs/utils.ts`:
  - New helper `findBestOpportunityByAddress(...)` to rank matches.
  - Preference order:
    1. Exact identifier matches with campaigns
    2. Exact identifier matches with APR breakdowns
    3. Prefix matches with campaigns
    4. Prefix matches with APR breakdowns
    5. Fallback to first exact/prefix match
- Updated both call sites to use this helper:
  - `calculateStrategyAPR(...)`
  - `calculateYearnVaultRewardsAPR(...)`
- Added regression test in `src/app/services/aprCalcs/utils.test.ts`:
  - Verifies exact identifier is preferred over earlier prefixed match (${VAULT_ADDRESS}JUMPER).

## Impact

- Corrects false-zero app reward outcomes when duplicate/prefixed opportunity identifiers exist.
- Improves reliability for USDC and any other vault/pool with similar identifier collisions.
- No API contract changes.

## Testing
- Added unit coverage for the exact-vs-prefixed selection case in:
- src/app/services/aprCalcs/utils.test.ts

# Human Testing
- yvvbUSDC app rewards section should now return a non-zero APR.