### PR TITLE
Update API for KAT TGE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ KONG_WEBHOOK_SECRET=
 # YDAEMON_BASE_URI=https://ydaemon.yearn.fi
 # MERKL_BASE_URI=https://api.merkl.xyz
 # COINGECKO_BASE_URI=https://api.coingecko.com/api/v3
-# COINGECKO_KATANA_PLATFORM_ID=katana
+# COINGECKO_KATANA_COIN_ID=katana-network-token
 # COINGECKO_API_KEY=
 
 # Debug

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ KONG_WEBHOOK_SECRET=
 # PORT=3000
 # YDAEMON_BASE_URI=https://ydaemon.yearn.fi
 # MERKL_BASE_URI=https://api.merkl.xyz
+# COINGECKO_BASE_URI=https://api.coingecko.com/api/v3
+# COINGECKO_KATANA_PLATFORM_ID=katana
+# COINGECKO_API_KEY=
 
 # Debug
 # APR_DEBUG_ENABLED=false

--- a/docs/api-integration-guide.md
+++ b/docs/api-integration-guide.md
@@ -113,7 +113,7 @@ curl -sS 'https://api.merkl.xyz/v4/opportunities/?chainId=747474&type=ERC20LOGPR
 
 When this repo needs a local KAT token price, it resolves prices in this order:
 
-1. CoinGecko by contract address on asset platform `katana`
+1. CoinGecko by coin ID `katana-network-token`
 2. yDaemon `GET /prices/all`
 
 Notes:

--- a/docs/api-integration-guide.md
+++ b/docs/api-integration-guide.md
@@ -29,10 +29,13 @@ At request time, the service:
 - External APIs:
   - `src/app/services/externalApis/yearnApi.ts`
   - `src/app/services/externalApis/merklApi.ts`
+  - `src/app/services/externalApis/katanaPriceService.ts`
   - `src/app/services/externalApis/merklBlacklist.ts`
 - APR matching logic:
   - `src/app/services/aprCalcs/yearnAprCalculator.ts`
   - `src/app/services/aprCalcs/utils.ts`
+- Shared reward-token allowlist:
+  - `src/app/services/katanaRewardTokens.ts`
 - Points logic:
   - `src/app/services/pointsCalcs/steerPointsCalculator.ts`
 
@@ -106,6 +109,19 @@ curl -sS 'https://api.merkl.xyz/v4/opportunities/?chainId=747474&type=ERC20LOGPR
 curl -sS 'https://api.merkl.xyz/v4/opportunities/?chainId=747474&type=ERC20LOGPROCESSOR&status=LIVE&campaigns=true&campaignId=0xc5a22d022154d5c64ff14b2f4071f134eb83cf159f9f846ad0ba0908a755e86d'
 ```
 
+### KAT price resolution utility
+
+When this repo needs a local KAT token price, it resolves prices in this order:
+
+1. CoinGecko by contract address on asset platform `katana`
+2. yDaemon `GET /prices/all`
+
+Notes:
+
+- yDaemon returns `chainId -> tokenAddress -> priceString`.
+- The yDaemon price strings use 6 decimals, matching the `yearn.fi` frontend path.
+- Wrapped KAT addresses fall back to canonical KAT before returning `0`.
+
 ## End-to-End Pipeline
 
 ### 1) Vault fetch
@@ -143,7 +159,7 @@ For each campaign in the chosen opportunity:
 
 - Campaign must have a matching APR breakdown:
   - `campaign.campaignId` equals `aprRecord.breakdowns[].identifier`
-- Campaign reward token must be allowlisted in `WRAPPED_KAT_ADDRESSES`:
+- Campaign reward token must be allowlisted in `KATANA_REWARD_TOKEN_ADDRESSES`:
   - `0x6E9C1F88a960fE63387eb4b71BC525a9313d8461`
   - `0x3ba1fbC4c3aEA775d335b31fb53778f46FD3a330`
   - `0x0161A31702d6CF715aaa912d64c6A190FD0093aa`
@@ -159,8 +175,8 @@ APR units:
 
 - `apr.extra.katanaRewardsAPR` (legacy alias)
 - `apr.extra.katanaAppRewardsAPR`
-- `apr.extra.fixedRateKatanaRewards` (currently hardcoded table)
-- `apr.extra.katanaBonusAPY` (hardcoded table)
+- `apr.extra.fixedRateKatanaRewards` (`0` post-TGE, kept for compatibility)
+- `apr.extra.katanaBonusAPY` (`0` post-TGE, kept for compatibility)
 - `apr.extra.katanaNativeYield` (`vault.apr.netAPR`)
 - `apr.extra.steerPointsPerDollar` (from strategy debt-weighted rates)
 
@@ -291,7 +307,7 @@ Snippet:
 }
 ```
 
-### 5) Service output snapshot (computed extras)
+### 5) Service output shape (post-TGE computed extras)
 
 From `DataCacheService.generateVaultAPRData()`:
 
@@ -302,8 +318,8 @@ From `DataCacheService.generateVaultAPRData()`:
     "symbol": "yvvbUSDC",
     "name": "USDC yVault",
     "katanaAppRewardsAPR": 0.005709245156139802,
-    "fixedRateKatanaRewards": 0.35,
-    "katanaBonusAPY": 0.068,
+    "fixedRateKatanaRewards": 0,
+    "katanaBonusAPY": 0,
     "katanaNativeYield": 0.03392437419763983,
     "steerPointsPerDollar": 0.1711
   },
@@ -312,8 +328,8 @@ From `DataCacheService.generateVaultAPRData()`:
     "symbol": "AUSD",
     "name": "AUSD yVault",
     "katanaAppRewardsAPR": 0,
-    "fixedRateKatanaRewards": 0.35,
-    "katanaBonusAPY": 0.068,
+    "fixedRateKatanaRewards": 0,
+    "katanaBonusAPY": 0,
     "katanaNativeYield": 0.11184248250750017,
     "steerPointsPerDollar": 0.1294
   },
@@ -322,8 +338,8 @@ From `DataCacheService.generateVaultAPRData()`:
     "symbol": "yvvbWBTC",
     "name": "WBTC yVault",
     "katanaAppRewardsAPR": 0,
-    "fixedRateKatanaRewards": 0.07,
-    "katanaBonusAPY": 0.016,
+    "fixedRateKatanaRewards": 0,
+    "katanaBonusAPY": 0,
     "katanaNativeYield": 0.0006326777539145123,
     "steerPointsPerDollar": 0
   }
@@ -338,7 +354,7 @@ From `DataCacheService.generateVaultAPRData()`:
 - Response is keyed by vault address.
 - Headers:
   - `Access-Control-Allow-Origin: *`
-  - `Cache-Control: public, max-age=0, s-maxage=900, stale-while-revalidate=600`
+  - `Cache-Control: public, max-age=0, s-maxage=60, stale-while-revalidate=60`
 
 ### `POST /api/webhook`
 
@@ -367,7 +383,7 @@ When a vault looks wrong:
 2. Query Merkl by `identifier=<vaultAddress>`.
 3. Check `aprRecord.breakdowns[].identifier`.
 4. Verify matching `campaigns[].campaignId` still exists after blacklist.
-5. Verify reward token is in `WRAPPED_KAT_ADDRESSES`.
+5. Verify reward token is in `KATANA_REWARD_TOKEN_ADDRESSES`.
 6. If multiple opportunities share an address prefix, ensure exact identifier match is chosen.
 7. Run the live debug script:
    - `bun run test:vault-debug:live -- --vault <address>`

--- a/docs/strategy-kat-rewards-plan.md
+++ b/docs/strategy-kat-rewards-plan.md
@@ -1,0 +1,55 @@
+# Strategy-Level KAT Rewards In `GET /api/vaults`
+
+## Summary
+
+- Reuse the existing `strategies[]` entries in the vault payload; do not add a new endpoint or parallel breakdown object.
+- Surface raw strategy APR on each active Morpho/Sushi strategy via `strategyRewardsAPR`, and keep `rewardToken` / `underlyingContract` populated there.
+- Change top-level `apr.extra.katanaAppRewardsAPR` to mean total app rewards across all paths: Yearn vault-level rewards plus weighted Morpho/Sushi strategy contributions.
+- Keep `/api/webhook` unchanged for now; this feature only changes the vault response shape.
+
+## Key Changes
+
+- Orchestration in `DataCacheService`:
+  - Instantiate `MorphoAprCalculator` and `SushiAprCalculator` alongside `YearnAprCalculator`.
+  - Include all three result maps in `generateVaultAPRData()` and flatten them into a single per-vault result set.
+  - Keep `katanaRewardsAPR` as the legacy alias of the new total `katanaAppRewardsAPR`, not just the Yearn-vault subset.
+- Strategy payload shaping:
+  - Populate `strategies[].strategyRewardsAPR` as the raw strategy APR in decimal form (`apr / 100`), not the weighted vault contribution.
+  - Populate `strategies[].rewardToken` and `strategies[].underlyingContract` from the matched Morpho/Sushi result.
+  - For active Morpho/Sushi strategies with no pool mapping or no Merkl opportunity, emit `strategyRewardsAPR: 0`; keep token/pool metadata undefined if it cannot be resolved.
+  - Leave unrelated strategies untouched.
+- Vault-level rollup:
+  - Compute strategy contribution APR internally as `rawStrategyApr * effectiveWeight`.
+  - Use `effectiveWeight = strategy.totalDebt / vault.tvl.totalAssets` when both values are parseable and positive.
+  - Fallback to `strategy.details.debtRatio / 10000` when actual debt weighting cannot be computed; clamp weight to `[0, 1]`.
+  - Set `apr.extra.katanaAppRewardsAPR = yearnVaultRewards + sum(strategy contributions)`.
+- Calculator and matching behavior:
+  - Keep the existing Morpho/Sushi calculators; they already produce per-strategy APR candidates keyed by strategy address.
+  - Update the strategy aggregation path so it does not rely on a single `find()` match for strategy decoration when complete strategy coverage is required.
+  - Adjust `calculateStrategyAPR()` to return an explicit zero-result placeholder even when the pool lookup is missing, so eligible strategies still surface in the response.
+  - Keep the current per-protocol wrapped-KAT address logic unless upstream campaigns change; no token-price conversion is needed for this feature because these calculators already return APR, not raw reward amounts.
+- Public API / docs:
+  - No new public endpoint.
+  - The public contract change is: `YearnStrategy.strategyRewardsAPR` becomes populated for active Morpho/Sushi strategies, and top-level `katanaAppRewardsAPR`/`katanaRewardsAPR` becomes the full weighted total.
+  - Update the API guide to document the difference between raw per-strategy APR and weighted vault total.
+
+## Test Plan
+
+- Extend `dataCache` tests to cover:
+  - A vault with Yearn + Morpho + Sushi results where raw strategy APRs are exposed on strategies and the top-level app rewards APR is the weighted total.
+  - Zero-result Morpho/Sushi strategies still appearing with `strategyRewardsAPR: 0`.
+  - Legacy alias `katanaRewardsAPR` matching the new total.
+- Add calculator tests for:
+  - Missing pool mapping returning a zero strategy result instead of disappearing.
+  - Missing opportunity returning zero APR with stable strategy output.
+- Keep route tests focused on `GET /api/vaults`:
+  - Verify the serialized response includes populated `strategyRewardsAPR` on strategies.
+  - Verify top-level `katanaAppRewardsAPR` reflects the weighted total, not just the Yearn-vault reward.
+- No webhook test changes beyond confirming existing component outputs remain unchanged.
+
+## Assumptions
+
+- Only `GET /api/vaults` needs strategy-level breakdown; `/api/webhook` remains top-level component-only.
+- `strategyRewardsAPR` is the raw APR for that strategy, so it will not sum directly to the top-level vault APR; the top-level field is weighted by allocation.
+- Actual `totalDebt` weighting is preferred over `debtRatio`, with `debtRatio` only as fallback.
+- Morpho and Sushi strategy detection continues to rely on the current `strategy.name` matching rules (`Morpho` and `Steer`).

--- a/src/app/api/vaults/route.test.ts
+++ b/src/app/api/vaults/route.test.ts
@@ -33,7 +33,9 @@ describe('/api/vaults route', () => {
 
     expect(response.status).toBe(200)
     expect(body).toEqual(payload)
-    expect(response.headers.get('Cache-Control')).toContain('s-maxage=900')
+    expect(response.headers.get('Cache-Control')).toBe(
+      'public, max-age=0, s-maxage=60, stale-while-revalidate=60',
+    )
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
   })
 

--- a/src/app/api/vaults/route.ts
+++ b/src/app/api/vaults/route.ts
@@ -17,7 +17,7 @@ function getCacheControlHeaderValue(): string {
   // - max-age=0: browsers should not cache
   // - s-maxage: CDN cache TTL
   // - stale-while-revalidate: serve stale while refreshing in the background
-  return 'public, max-age=0, s-maxage=900, stale-while-revalidate=600'
+  return 'public, max-age=0, s-maxage=60, stale-while-revalidate=60'
 }
 
 export async function GET(): Promise<NextResponse> {

--- a/src/app/api/webhook/route.test.ts
+++ b/src/app/api/webhook/route.test.ts
@@ -1,0 +1,125 @@
+import { createHmac } from 'node:crypto'
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  mockGenerateVaultAPRData: vi.fn(),
+}))
+
+vi.mock('../../services/dataCache', () => ({
+  DataCacheService: vi.fn().mockImplementation(() => ({
+    generateVaultAPRData: mocks.mockGenerateVaultAPRData,
+  })),
+}))
+
+import { POST } from './route'
+
+const WEBHOOK_SECRET = 'test-secret'
+const VAULT_ADDRESS = '0x00000000000000000000000000000000000000aa'
+
+const buildSignedRequest = (body: Record<string, unknown>): NextRequest => {
+  const rawBody = JSON.stringify(body)
+  const timestamp = Math.floor(Date.now() / 1000)
+  const signature = createHmac('sha256', WEBHOOK_SECRET)
+    .update(`${timestamp}.${rawBody}`, 'utf8')
+    .digest('hex')
+
+  return new NextRequest('http://localhost/api/webhook', {
+    method: 'POST',
+    body: rawBody,
+    headers: {
+      'content-type': 'application/json',
+      'kong-signature': `t=${timestamp},v1=${signature}`,
+    },
+  })
+}
+
+describe('/api/webhook route', () => {
+  beforeEach(() => {
+    process.env.KONG_WEBHOOK_SECRET = WEBHOOK_SECRET
+    mocks.mockGenerateVaultAPRData.mockReset()
+  })
+
+  it('returns zeroed legacy Katana fields while keeping component names stable', async () => {
+    mocks.mockGenerateVaultAPRData.mockResolvedValue({
+      [VAULT_ADDRESS]: {
+        address: VAULT_ADDRESS,
+        symbol: 'yvKAT',
+        name: 'KAT Vault',
+        chainID: 747474,
+        strategies: [],
+        apr: {
+          extra: {
+            katanaAppRewardsAPR: 0.1234,
+            fixedRateKatanaRewards: 0,
+            katanaBonusAPY: 0,
+            katanaNativeYield: 0.0456,
+            steerPointsPerDollar: 0.5,
+          },
+        },
+      },
+    })
+
+    const response = await POST(
+      buildSignedRequest({
+        vaults: [VAULT_ADDRESS],
+        chainId: 747474,
+        blockNumber: '123',
+        blockTime: '456',
+        subscription: {
+          labels: ['katana'],
+        },
+      }),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual([
+      {
+        chainId: 747474,
+        address: VAULT_ADDRESS,
+        label: 'katana',
+        component: 'katanaAppRewardsAPR',
+        value: 0.1234,
+        blockNumber: '123',
+        blockTime: '456',
+      },
+      {
+        chainId: 747474,
+        address: VAULT_ADDRESS,
+        label: 'katana',
+        component: 'fixedRateKatanaRewards',
+        value: 0,
+        blockNumber: '123',
+        blockTime: '456',
+      },
+      {
+        chainId: 747474,
+        address: VAULT_ADDRESS,
+        label: 'katana',
+        component: 'katanaBonusAPY',
+        value: 0,
+        blockNumber: '123',
+        blockTime: '456',
+      },
+      {
+        chainId: 747474,
+        address: VAULT_ADDRESS,
+        label: 'katana',
+        component: 'katanaNativeYield',
+        value: 0.0456,
+        blockNumber: '123',
+        blockTime: '456',
+      },
+      {
+        chainId: 747474,
+        address: VAULT_ADDRESS,
+        label: 'katana',
+        component: 'steerPointsPerDollar',
+        value: 0.5,
+        blockNumber: '123',
+        blockTime: '456',
+      },
+    ])
+  })
+})

--- a/src/app/config/index.ts
+++ b/src/app/config/index.ts
@@ -25,8 +25,8 @@ export const config = {
   coingeckoApiUrl:
     process.env.COINGECKO_BASE_URI || 'https://api.coingecko.com/api/v3',
   coingeckoApiKey: process.env.COINGECKO_API_KEY,
-  coingeckoKatanaPlatformId:
-    process.env.COINGECKO_KATANA_PLATFORM_ID || 'katana',
+  coingeckoKatanaCoinId:
+    process.env.COINGECKO_KATANA_COIN_ID || 'katana-network-token',
   aprDebugEnabled: parseBoolean(process.env.APR_DEBUG_ENABLED),
   aprDebugVaultAddress: process.env.APR_DEBUG_VAULT_ADDRESS?.toLowerCase(),
   aprDebugSampleLimit: parsePositiveInteger(process.env.APR_DEBUG_SAMPLE_LIMIT),

--- a/src/app/config/index.ts
+++ b/src/app/config/index.ts
@@ -22,10 +22,14 @@ export const config = {
   rpcUrl: process.env.RPC_URL_KATANA!,
   yearnApiUrl: process.env.YDAEMON_BASE_URI || 'https://ydaemon.yearn.fi',
   merklApiUrl: process.env.MERKL_BASE_URI || 'https://api.merkl.xyz',
+  coingeckoApiUrl:
+    process.env.COINGECKO_BASE_URI || 'https://api.coingecko.com/api/v3',
+  coingeckoApiKey: process.env.COINGECKO_API_KEY,
+  coingeckoKatanaPlatformId:
+    process.env.COINGECKO_KATANA_PLATFORM_ID || 'katana',
   aprDebugEnabled: parseBoolean(process.env.APR_DEBUG_ENABLED),
   aprDebugVaultAddress: process.env.APR_DEBUG_VAULT_ADDRESS?.toLowerCase(),
   aprDebugSampleLimit: parsePositiveInteger(process.env.APR_DEBUG_SAMPLE_LIMIT),
-  katanaTokenFDV: 1_000_000_000, // 1B FDV default
   multicallAddress: '0xcA11bde05977b3631167028862bE2a173976CA11' as const,
 }
 

--- a/src/app/services/aprCalcs/types.ts
+++ b/src/app/services/aprCalcs/types.ts
@@ -1,6 +1,8 @@
+import type { YearnVault } from '../../types'
+
 export interface APRCalculator {
   calculateVaultAPRs(
-    vaults: any[]
+    vaults: YearnVault[]
   ): Promise<Record<string, RewardCalculatorResult[]>>
 }
 

--- a/src/app/services/aprCalcs/yearnAprCalculator.ts
+++ b/src/app/services/aprCalcs/yearnAprCalculator.ts
@@ -2,14 +2,9 @@ import type { YearnVault } from '../../types'
 import { MerklApiService } from '../externalApis/merklApi'
 import { YearnApiService } from '../externalApis/yearnApi'
 import { ContractReaderService } from '../contractReader'
+import { KATANA_REWARD_TOKEN_ADDRESSES } from '../katanaRewardTokens'
 import type { APRCalculator, RewardCalculatorResult } from './types'
 import { calculateYearnVaultRewardsAPR } from './utils'
-
-const WRAPPED_KAT_ADDRESSES = [
-  '0x6E9C1F88a960fE63387eb4b71BC525a9313d8461', // v2WrappedKat,
-  '0x3ba1fbC4c3aEA775d335b31fb53778f46FD3a330', // v1WrappedKat
-  '0x0161A31702d6CF715aaa912d64c6A190FD0093aa', // KAT
-]
 
 /**
  * Calculates the APRs for rewards that are forwarded directly to Yearn vaults,
@@ -47,7 +42,7 @@ export class YearnAprCalculator implements APRCalculator {
         vault.address,
         yearnOpportunities,
         'yearn',
-        WRAPPED_KAT_ADDRESSES
+        [...KATANA_REWARD_TOKEN_ADDRESSES]
       )
       return [vault.address, vaultResults]
     })
@@ -67,7 +62,7 @@ export class YearnAprCalculator implements APRCalculator {
         vault.address,
         FixedRateOpportunities,
         'fixed rate',
-        WRAPPED_KAT_ADDRESSES
+        [...KATANA_REWARD_TOKEN_ADDRESSES]
       )
       return [vault.address, vaultResults]
     })

--- a/src/app/services/dataCache.test.ts
+++ b/src/app/services/dataCache.test.ts
@@ -32,7 +32,9 @@ vi.mock('./aprCalcs/debugLogger', () => ({
 
 import { DataCacheService } from './dataCache'
 
-const makeVault = (): YearnVault => ({
+const STRATEGY_ADDRESS = '0x00000000000000000000000000000000000000cc'
+
+const makeVault = (overrides: Partial<YearnVault> = {}): YearnVault => ({
   address: '0x00000000000000000000000000000000000000aa',
   symbol: 'TST',
   name: 'Test Vault',
@@ -41,6 +43,7 @@ const makeVault = (): YearnVault => ({
   apr: {
     netAPR: 0.02,
   },
+  ...overrides,
 })
 
 describe('DataCacheService.generateVaultAPRData', () => {
@@ -78,7 +81,22 @@ describe('DataCacheService.generateVaultAPRData', () => {
   })
 
   it('aggregates vault APR when rewards data exists', async () => {
-    const vault = makeVault()
+    const vault = makeVault({
+      strategies: [
+        {
+          address: STRATEGY_ADDRESS,
+          name: 'Strategy',
+          status: 'active',
+          details: {
+            totalDebt: '1',
+            totalGain: '0',
+            totalLoss: '0',
+            lastReport: 0,
+            debtRatio: 5000,
+          },
+        },
+      ],
+    })
     mocks.mockGetVaults.mockResolvedValue([vault])
     mocks.mockCalculateVaultAPRs.mockResolvedValue({
       [vault.address]: [
@@ -96,6 +114,20 @@ describe('DataCacheService.generateVaultAPRData', () => {
             weight: 0,
           },
         },
+        {
+          strategyAddress: STRATEGY_ADDRESS,
+          poolAddress: '0x00000000000000000000000000000000000000dd',
+          poolType: 'morpho',
+          breakdown: {
+            apr: 4,
+            token: {
+              address: '0x00000000000000000000000000000000000000bb',
+              symbol: 'KAT',
+              decimals: 18,
+            },
+            weight: 0,
+          },
+        },
       ],
     })
 
@@ -105,6 +137,16 @@ describe('DataCacheService.generateVaultAPRData', () => {
 
     expect(aggregatedVault.address).toBe(vault.address)
     expect(aggregatedVault.apr?.extra?.katanaAppRewardsAPR).toBe(0.1)
+    expect(aggregatedVault.apr?.extra?.fixedRateKatanaRewards).toBe(0)
+    expect(aggregatedVault.apr?.extra?.katanaBonusAPY).toBe(0)
+    expect(aggregatedVault.strategies[0].rewardToken).toEqual({
+      address: '0x00000000000000000000000000000000000000bb',
+      symbol: 'KAT',
+      decimals: 18,
+    })
+    expect(aggregatedVault.strategies[0].rewardToken).not.toHaveProperty(
+      'assumedFDV',
+    )
     expect(mocks.logVaultAprDebug).toHaveBeenCalledWith(
       expect.objectContaining({
         stage: 'result_summary',

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -25,44 +25,6 @@ export interface APRDataCache {
 
 export type { TokenBreakdown }
 
-/**
- * This is a bonus for users who do not withdraw from the vaults over a certain period of time.
- * It is provided by the Katana team.
- */
-const katanaBonusAPY: Record<
-  'yvvbETH' | 'yvvbUSDC' | 'yvvbUSDT' | 'AUSD' | 'yvvbWBTC' | 'yvvbUSDS',
-  number
-> = {
-  yvvbETH: 0.016,
-  yvvbUSDC: 0.068,
-  yvvbUSDT: 0.068,
-  AUSD: 0.068,
-  yvvbWBTC: 0.016,
-  yvvbUSDS: 0.0,
-}
-
-const HARDCODED_FIXED_RATE_APR: Record<
-  | 'yvvbETH'
-  | 'yvvbUSDC'
-  | 'yvvbUSDT'
-  | 'AUSD'
-  | 'yvvbWBTC'
-  | 'yvvbUSDS'
-  | 'yvwstETH',
-  number
-> = {
-  yvvbETH: 0.14,
-  yvvbUSDC: 0.35,
-  yvvbUSDT: 0.35,
-  AUSD: 0.35,
-  yvvbWBTC: 0.07,
-  yvvbUSDS: 0.0,
-  yvwstETH: 0.0,
-}
-
-// Default FDV value
-const FDV = 1_000_000_000
-
 export class DataCacheService {
   private yearnApi: YearnApiService
   private yearnAprCalculator: YearnAprCalculator
@@ -200,7 +162,7 @@ export class DataCacheService {
 
       const strategyData = result?.breakdown
         ? {
-            rewardToken: { ...result.breakdown.token, assumedFDV: FDV },
+            rewardToken: { ...result.breakdown.token },
             underlyingContract: result.poolAddress,
           }
         : {
@@ -232,27 +194,10 @@ export class DataCacheService {
       0,
     )
 
-    // use this when fixed rate pools are live
-    // const fixedRateResults = vaultLevelResults.filter(
-    //   (r) => r.poolType === 'fixed rate'
-    // )
-    // const fixedRateVaultAPR = fixedRateResults.reduce(
-    //   (sum, result) =>
-    //     sum + (result.breakdown?.apr ? result.breakdown.apr / 100 : 0),
-    //   0
-    // )
+    // Legacy fields are kept for consumer compatibility, but both programs are retired post-TGE.
+    const fixedRateFromHardcoded = 0
+    const vaultKatanaBonusAPY = 0
 
-    // override with hardcoded values until new campaigns are live
-    const fixedRateFromHardcoded =
-      HARDCODED_FIXED_RATE_APR[
-        vault.symbol as keyof typeof HARDCODED_FIXED_RATE_APR
-      ] || 0
-
-    // Get the katana bonus APY for this vault based on its symbol
-    const vaultKatanaBonusAPY =
-      katanaBonusAPY[vault.symbol as keyof typeof katanaBonusAPY] || 0
-
-    // katanaNativeYield is the greater of the second field or netAPR
     const katanaNativeYield = vault.apr?.netAPR || 0
 
     const apr = {

--- a/src/app/services/externalApis/katanaPriceService.test.ts
+++ b/src/app/services/externalApis/katanaPriceService.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { config } from '../../config'
+import { CANONICAL_KAT_ADDRESS } from '../katanaRewardTokens'
+
+const WRAPPED_KAT_ADDRESS = '0x6E9C1F88a960fE63387eb4b71BC525a9313d8461'
+
+const mocks = vi.hoisted(() => ({
+  axiosGet: vi.fn(),
+}))
+
+vi.mock('axios', () => ({
+  default: {
+    get: mocks.axiosGet,
+  },
+}))
+
+import { KatanaPriceService, parseYDaemonPriceUsd } from './katanaPriceService'
+
+describe('KatanaPriceService', () => {
+  beforeEach(() => {
+    mocks.axiosGet.mockReset()
+  })
+
+  it('returns CoinGecko price when available for the requested address', async () => {
+    mocks.axiosGet.mockResolvedValueOnce({
+      data: {
+        [CANONICAL_KAT_ADDRESS.toLowerCase()]: {
+          usd: 1.25,
+        },
+      },
+    })
+
+    const service = new KatanaPriceService()
+    const price = await service.getTokenPriceUsd(
+      config.katanaChainId,
+      CANONICAL_KAT_ADDRESS,
+    )
+
+    expect(price).toBe(1.25)
+    expect(mocks.axiosGet).toHaveBeenCalledWith(
+      `${config.coingeckoApiUrl}/simple/token_price/${config.coingeckoKatanaPlatformId}`,
+      expect.objectContaining({
+        params: {
+          contract_addresses: CANONICAL_KAT_ADDRESS.toLowerCase(),
+          vs_currencies: 'usd',
+        },
+      }),
+    )
+  })
+
+  it('falls back to yDaemon prices and parses 6-decimal strings', async () => {
+    mocks.axiosGet.mockResolvedValueOnce({ data: {} })
+    mocks.axiosGet.mockResolvedValueOnce({
+      data: {
+        [config.katanaChainId]: {
+          [CANONICAL_KAT_ADDRESS.toLowerCase()]: '1250000',
+        },
+      },
+    })
+
+    const service = new KatanaPriceService()
+    const price = await service.getTokenPriceUsd(
+      config.katanaChainId,
+      CANONICAL_KAT_ADDRESS,
+    )
+
+    expect(price).toBe(1.25)
+    expect(mocks.axiosGet).toHaveBeenNthCalledWith(
+      2,
+      `${config.yearnApiUrl}/prices/all`,
+    )
+  })
+
+  it('aliases wrapped KAT addresses to the canonical KAT price', async () => {
+    mocks.axiosGet.mockResolvedValueOnce({
+      data: {
+        [CANONICAL_KAT_ADDRESS.toLowerCase()]: {
+          usd: 2.5,
+        },
+      },
+    })
+
+    const service = new KatanaPriceService()
+    const price = await service.getTokenPriceUsd(
+      config.katanaChainId,
+      WRAPPED_KAT_ADDRESS,
+    )
+
+    expect(price).toBe(2.5)
+    expect(mocks.axiosGet).toHaveBeenCalledWith(
+      `${config.coingeckoApiUrl}/simple/token_price/${config.coingeckoKatanaPlatformId}`,
+      expect.objectContaining({
+        params: {
+          contract_addresses: [
+            WRAPPED_KAT_ADDRESS.toLowerCase(),
+            CANONICAL_KAT_ADDRESS.toLowerCase(),
+          ].join(','),
+          vs_currencies: 'usd',
+        },
+      }),
+    )
+  })
+
+  it('returns 0 when both CoinGecko and yDaemon fail to provide a price', async () => {
+    mocks.axiosGet.mockResolvedValueOnce({ data: {} })
+    mocks.axiosGet.mockResolvedValueOnce({
+      data: {
+        [config.katanaChainId]: {},
+      },
+    })
+
+    const service = new KatanaPriceService()
+    const price = await service.getTokenPriceUsd(
+      config.katanaChainId,
+      CANONICAL_KAT_ADDRESS,
+    )
+
+    expect(price).toBe(0)
+  })
+})
+
+describe('parseYDaemonPriceUsd', () => {
+  it('parses yDaemon 6-decimal integer strings', () => {
+    expect(parseYDaemonPriceUsd('1234567')).toBe(1.234567)
+  })
+})

--- a/src/app/services/externalApis/katanaPriceService.test.ts
+++ b/src/app/services/externalApis/katanaPriceService.test.ts
@@ -24,7 +24,7 @@ describe('KatanaPriceService', () => {
   it('returns CoinGecko price when available for the requested address', async () => {
     mocks.axiosGet.mockResolvedValueOnce({
       data: {
-        [CANONICAL_KAT_ADDRESS.toLowerCase()]: {
+        [config.coingeckoKatanaCoinId]: {
           usd: 1.25,
         },
       },
@@ -38,10 +38,10 @@ describe('KatanaPriceService', () => {
 
     expect(price).toBe(1.25)
     expect(mocks.axiosGet).toHaveBeenCalledWith(
-      `${config.coingeckoApiUrl}/simple/token_price/${config.coingeckoKatanaPlatformId}`,
+      `${config.coingeckoApiUrl}/simple/price`,
       expect.objectContaining({
         params: {
-          contract_addresses: CANONICAL_KAT_ADDRESS.toLowerCase(),
+          ids: config.coingeckoKatanaCoinId,
           vs_currencies: 'usd',
         },
       }),
@@ -71,11 +71,12 @@ describe('KatanaPriceService', () => {
     )
   })
 
-  it('aliases wrapped KAT addresses to the canonical KAT price', async () => {
+  it('aliases wrapped KAT addresses to the canonical KAT yDaemon price', async () => {
+    mocks.axiosGet.mockResolvedValueOnce({ data: {} })
     mocks.axiosGet.mockResolvedValueOnce({
       data: {
-        [CANONICAL_KAT_ADDRESS.toLowerCase()]: {
-          usd: 2.5,
+        [config.katanaChainId]: {
+          [CANONICAL_KAT_ADDRESS.toLowerCase()]: '2500000',
         },
       },
     })
@@ -87,17 +88,9 @@ describe('KatanaPriceService', () => {
     )
 
     expect(price).toBe(2.5)
-    expect(mocks.axiosGet).toHaveBeenCalledWith(
-      `${config.coingeckoApiUrl}/simple/token_price/${config.coingeckoKatanaPlatformId}`,
-      expect.objectContaining({
-        params: {
-          contract_addresses: [
-            WRAPPED_KAT_ADDRESS.toLowerCase(),
-            CANONICAL_KAT_ADDRESS.toLowerCase(),
-          ].join(','),
-          vs_currencies: 'usd',
-        },
-      }),
+    expect(mocks.axiosGet).toHaveBeenNthCalledWith(
+      2,
+      `${config.yearnApiUrl}/prices/all`,
     )
   })
 

--- a/src/app/services/externalApis/katanaPriceService.ts
+++ b/src/app/services/externalApis/katanaPriceService.ts
@@ -1,0 +1,133 @@
+import axios from 'axios'
+import { formatUnits } from 'viem'
+import { config } from '../../config'
+import { getKatanaPriceLookupAddresses } from '../katanaRewardTokens'
+
+type CoinGeckoTokenPriceResponse = Record<
+  string,
+  {
+    usd?: number
+  }
+>
+
+type YDaemonPricesChain = Record<string, Record<string, string>>
+
+const YDAEMON_PRICE_DECIMALS = 6
+
+const isPositiveFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value > 0
+
+const parseYDaemonPriceUsd = (rawPrice: unknown): number => {
+  if (typeof rawPrice !== 'string' || rawPrice.length === 0) {
+    return 0
+  }
+
+  try {
+    const normalizedPrice = Number(
+      formatUnits(BigInt(rawPrice), YDAEMON_PRICE_DECIMALS),
+    )
+    return isPositiveFiniteNumber(normalizedPrice) ? normalizedPrice : 0
+  } catch {
+    const parsedPrice = Number(rawPrice)
+    return isPositiveFiniteNumber(parsedPrice) ? parsedPrice : 0
+  }
+}
+
+export class KatanaPriceService {
+  private readonly coingeckoApiUrl: string
+  private readonly coingeckoKatanaPlatformId: string
+  private readonly yearnApiUrl: string
+  private readonly coinGeckoHeaders?: Record<string, string>
+
+  constructor() {
+    this.coingeckoApiUrl = config.coingeckoApiUrl
+    this.coingeckoKatanaPlatformId = config.coingeckoKatanaPlatformId
+    this.yearnApiUrl = config.yearnApiUrl
+    this.coinGeckoHeaders = config.coingeckoApiKey
+      ? { 'x-cg-demo-api-key': config.coingeckoApiKey }
+      : undefined
+  }
+
+  async getTokenPriceUsd(
+    chainId: number,
+    tokenAddress: string,
+  ): Promise<number> {
+    const lookupAddresses = getKatanaPriceLookupAddresses(tokenAddress)
+
+    const coinGeckoPrice = await this.getCoinGeckoPriceUsd(lookupAddresses)
+    if (coinGeckoPrice > 0) {
+      return coinGeckoPrice
+    }
+
+    const yDaemonPrice = await this.getYDaemonPriceUsd(chainId, lookupAddresses)
+    if (yDaemonPrice > 0) {
+      return yDaemonPrice
+    }
+
+    return 0
+  }
+
+  private async getCoinGeckoPriceUsd(addresses: string[]): Promise<number> {
+    try {
+      const response = await axios.get<CoinGeckoTokenPriceResponse>(
+        `${this.coingeckoApiUrl}/simple/token_price/${this.coingeckoKatanaPlatformId}`,
+        {
+          params: {
+            contract_addresses: addresses.join(','),
+            vs_currencies: 'usd',
+          },
+          headers: this.coinGeckoHeaders,
+        },
+      )
+
+      for (const address of addresses) {
+        const price = response.data?.[address]?.usd
+        if (isPositiveFiniteNumber(price)) {
+          return price
+        }
+      }
+    } catch (error) {
+      console.error('Error fetching CoinGecko token price:', error)
+    }
+
+    return 0
+  }
+
+  private async getYDaemonPriceUsd(
+    chainId: number,
+    addresses: string[],
+  ): Promise<number> {
+    try {
+      const response = await axios.get<YDaemonPricesChain>(
+        `${this.yearnApiUrl}/prices/all`,
+      )
+      const chainPrices = response.data?.[String(chainId)]
+
+      if (!chainPrices) {
+        return 0
+      }
+
+      const normalizedChainPrices = new Map(
+        Object.entries(chainPrices).map(([address, price]) => [
+          address.toLowerCase(),
+          price,
+        ]),
+      )
+
+      for (const address of addresses) {
+        const price = parseYDaemonPriceUsd(
+          normalizedChainPrices.get(address.toLowerCase()),
+        )
+        if (price > 0) {
+          return price
+        }
+      }
+    } catch (error) {
+      console.error('Error fetching yDaemon token prices:', error)
+    }
+
+    return 0
+  }
+}
+
+export { parseYDaemonPriceUsd }

--- a/src/app/services/externalApis/katanaPriceService.ts
+++ b/src/app/services/externalApis/katanaPriceService.ts
@@ -35,13 +35,13 @@ const parseYDaemonPriceUsd = (rawPrice: unknown): number => {
 
 export class KatanaPriceService {
   private readonly coingeckoApiUrl: string
-  private readonly coingeckoKatanaPlatformId: string
+  private readonly coingeckoKatanaCoinId: string
   private readonly yearnApiUrl: string
   private readonly coinGeckoHeaders?: Record<string, string>
 
   constructor() {
     this.coingeckoApiUrl = config.coingeckoApiUrl
-    this.coingeckoKatanaPlatformId = config.coingeckoKatanaPlatformId
+    this.coingeckoKatanaCoinId = config.coingeckoKatanaCoinId
     this.yearnApiUrl = config.yearnApiUrl
     this.coinGeckoHeaders = config.coingeckoApiKey
       ? { 'x-cg-demo-api-key': config.coingeckoApiKey }
@@ -54,7 +54,7 @@ export class KatanaPriceService {
   ): Promise<number> {
     const lookupAddresses = getKatanaPriceLookupAddresses(tokenAddress)
 
-    const coinGeckoPrice = await this.getCoinGeckoPriceUsd(lookupAddresses)
+    const coinGeckoPrice = await this.getCoinGeckoPriceUsd()
     if (coinGeckoPrice > 0) {
       return coinGeckoPrice
     }
@@ -67,24 +67,22 @@ export class KatanaPriceService {
     return 0
   }
 
-  private async getCoinGeckoPriceUsd(addresses: string[]): Promise<number> {
+  private async getCoinGeckoPriceUsd(): Promise<number> {
     try {
       const response = await axios.get<CoinGeckoTokenPriceResponse>(
-        `${this.coingeckoApiUrl}/simple/token_price/${this.coingeckoKatanaPlatformId}`,
+        `${this.coingeckoApiUrl}/simple/price`,
         {
           params: {
-            contract_addresses: addresses.join(','),
+            ids: this.coingeckoKatanaCoinId,
             vs_currencies: 'usd',
           },
           headers: this.coinGeckoHeaders,
         },
       )
 
-      for (const address of addresses) {
-        const price = response.data?.[address]?.usd
-        if (isPositiveFiniteNumber(price)) {
-          return price
-        }
+      const price = response.data?.[this.coingeckoKatanaCoinId]?.usd
+      if (isPositiveFiniteNumber(price)) {
+        return price
       }
     } catch (error) {
       console.error('Error fetching CoinGecko token price:', error)

--- a/src/app/services/katanaRewardTokens.ts
+++ b/src/app/services/katanaRewardTokens.ts
@@ -1,0 +1,36 @@
+export const KATANA_REWARD_TOKEN_ADDRESSES = [
+  '0x6E9C1F88a960fE63387eb4b71BC525a9313d8461', // v2WrappedKat
+  '0x3ba1fbC4c3aEA775d335b31fb53778f46FD3a330', // v1WrappedKat
+  '0x0161A31702d6CF715aaa912d64c6A190FD0093aa', // KAT
+] as const
+
+export const CANONICAL_KAT_ADDRESS =
+  '0x0161A31702d6CF715aaa912d64c6A190FD0093aa'
+
+const REWARD_TOKEN_ADDRESS_SET = new Set(
+  KATANA_REWARD_TOKEN_ADDRESSES.map((address) => address.toLowerCase()),
+)
+
+export const isKatanaRewardTokenAddress = (address?: string): boolean => {
+  if (!address) {
+    return false
+  }
+
+  return REWARD_TOKEN_ADDRESS_SET.has(address.toLowerCase())
+}
+
+export const getKatanaPriceLookupAddresses = (
+  tokenAddress: string,
+): string[] => {
+  const normalizedAddress = tokenAddress.toLowerCase()
+  const canonicalAddress = CANONICAL_KAT_ADDRESS.toLowerCase()
+
+  if (
+    !isKatanaRewardTokenAddress(normalizedAddress) ||
+    normalizedAddress === canonicalAddress
+  ) {
+    return [normalizedAddress]
+  }
+
+  return [normalizedAddress, canonicalAddress]
+}


### PR DESCRIPTION
## Summary

This PR aligns the Katana APR service with the TGE-era API contract.

It removes the pre-TGE hardcoded APR assumptions, keeps legacy fields in place with `0` values for compatibility, adds a reusable KAT price lookup service, tightens `/api/vaults` cache freshness, and updates tests/docs to reflect the new behavior.

## What Changed

- Removed the hardcoded `fixedRateKatanaRewards` and `katanaBonusAPY` tables from the APR aggregation path.
- Kept both legacy fields in the API/webhook outputs, but now always emit `0` post-TGE.
- Stopped injecting the fake `$1B FDV` / `assumedFDV` metadata into strategy reward tokens.
- Added a `KatanaPriceService` with:
  - CoinGecko coin ID lookup via `katana-network-token`
  - yDaemon `/prices/all` fallback
  - wrapped-KAT alias handling for the fallback path
- Added CoinGecko config/env support:
  - `COINGECKO_BASE_URI`
  - `COINGECKO_KATANA_COIN_ID`
  - `COINGECKO_API_KEY`
- Reduced `/api/vaults` cache headers from `s-maxage=900, stale-while-revalidate=600` to `s-maxage=60, stale-while-revalidate=60`.
- Updated the API integration guide to reflect the post-TGE behavior and current KAT price lookup strategy.
- Added a follow-up planning doc for strategy-level KAT reward breakdowns in `docs/strategy-kat-rewards-plan.md`.

## Notes

- `katanaAppRewardsAPR` is still sourced from Merkl APR breakdowns in this branch; it is not recalculated locally from KAT token price yet.
- The new `KatanaPriceService` is groundwork for future price-derived APR work and is covered by tests, but it is not yet wired into `generateVaultAPRData()`.
- Webhook component names remain unchanged for downstream compatibility.

## Testing

- `bun run lint`
- `bun run test:run`
