### PR TITLE
Update API for KAT TGE - addendum

### DIFF
--- a/docs/api-integration-guide.md
+++ b/docs/api-integration-guide.md
@@ -121,6 +121,8 @@ Notes:
 - yDaemon returns `chainId -> tokenAddress -> priceString`.
 - The yDaemon price strings use 6 decimals, matching the `yearn.fi` frontend path.
 - Wrapped KAT addresses fall back to canonical KAT before returning `0`.
+- KAT price lookups are cached in-process for 60 seconds, with request deduplication across concurrent callers.
+- If a refresh fails, the service can reuse a stale cached KAT price for up to 5 minutes to reduce CoinGecko rate-limit risk.
 
 ## End-to-End Pipeline
 
@@ -175,7 +177,7 @@ APR units:
 
 - `apr.extra.katanaRewardsAPR` (legacy alias)
 - `apr.extra.katanaAppRewardsAPR`
-- `apr.extra.fixedRateKatanaRewards` (`0` post-TGE, kept for compatibility)
+- `apr.extra.fixedRateKatanaRewards` (legacy fixed-rate schedule scaled by `live KAT price / assumed $0.10 KAT price`)
 - `apr.extra.katanaBonusAPY` (`0` post-TGE, kept for compatibility)
 - `apr.extra.katanaNativeYield` (`vault.apr.netAPR`)
 - `apr.extra.steerPointsPerDollar` (from strategy debt-weighted rates)
@@ -311,6 +313,13 @@ Snippet:
 
 From `DataCacheService.generateVaultAPRData()`:
 
+Notes:
+
+- `katanaAppRewardsAPR` comes from Merkl APR breakdowns.
+- `fixedRateKatanaRewards` uses the legacy fixed-rate table as the APR basis at an assumed `KAT = $0.10 USD`, then scales by `livePrice / 0.10`.
+- `katanaBonusAPY` remains `0`.
+- The example `fixedRateKatanaRewards` values below assume `KAT = $0.10 USD`, which matches the historical fixed-rate program basis.
+
 ```json
 [
   {
@@ -318,7 +327,7 @@ From `DataCacheService.generateVaultAPRData()`:
     "symbol": "yvvbUSDC",
     "name": "USDC yVault",
     "katanaAppRewardsAPR": 0.005709245156139802,
-    "fixedRateKatanaRewards": 0,
+    "fixedRateKatanaRewards": 0.35,
     "katanaBonusAPY": 0,
     "katanaNativeYield": 0.03392437419763983,
     "steerPointsPerDollar": 0.1711
@@ -328,7 +337,7 @@ From `DataCacheService.generateVaultAPRData()`:
     "symbol": "AUSD",
     "name": "AUSD yVault",
     "katanaAppRewardsAPR": 0,
-    "fixedRateKatanaRewards": 0,
+    "fixedRateKatanaRewards": 0.35,
     "katanaBonusAPY": 0,
     "katanaNativeYield": 0.11184248250750017,
     "steerPointsPerDollar": 0.1294
@@ -338,7 +347,7 @@ From `DataCacheService.generateVaultAPRData()`:
     "symbol": "yvvbWBTC",
     "name": "WBTC yVault",
     "katanaAppRewardsAPR": 0,
-    "fixedRateKatanaRewards": 0,
+    "fixedRateKatanaRewards": 0.07,
     "katanaBonusAPY": 0,
     "katanaNativeYield": 0.0006326777539145123,
     "steerPointsPerDollar": 0

--- a/src/app/services/dataCache.test.ts
+++ b/src/app/services/dataCache.test.ts
@@ -3,6 +3,7 @@ import type { YearnVault } from '../types'
 
 const mocks = vi.hoisted(() => ({
   mockGetVaults: vi.fn(),
+  mockGetTokenPriceUsd: vi.fn(),
   mockCalculateVaultAPRs: vi.fn(),
   mockCalculateSteerPoints: vi.fn(),
   logVaultAprDebug: vi.fn(),
@@ -11,6 +12,12 @@ const mocks = vi.hoisted(() => ({
 vi.mock('./externalApis/yearnApi', () => ({
   YearnApiService: vi.fn().mockImplementation(() => ({
     getVaults: mocks.mockGetVaults,
+  })),
+}))
+
+vi.mock('./externalApis/katanaPriceService', () => ({
+  KatanaPriceService: vi.fn().mockImplementation(() => ({
+    getTokenPriceUsd: mocks.mockGetTokenPriceUsd,
   })),
 }))
 
@@ -49,9 +56,11 @@ const makeVault = (overrides: Partial<YearnVault> = {}): YearnVault => ({
 describe('DataCacheService.generateVaultAPRData', () => {
   beforeEach(() => {
     mocks.mockGetVaults.mockReset()
+    mocks.mockGetTokenPriceUsd.mockReset()
     mocks.mockCalculateVaultAPRs.mockReset()
     mocks.mockCalculateSteerPoints.mockReset()
     mocks.logVaultAprDebug.mockReset()
+    mocks.mockGetTokenPriceUsd.mockResolvedValue(1)
     mocks.mockCalculateSteerPoints.mockReturnValue(0)
   })
 
@@ -154,5 +163,36 @@ describe('DataCacheService.generateVaultAPRData', () => {
         reason: 'vault_results_aggregated',
       }),
     )
+  })
+
+  it('scales fixed rate rewards by the live-to-assumed KAT price ratio', async () => {
+    const vault = makeVault({
+      symbol: 'yvvbUSDC',
+    })
+    mocks.mockGetVaults.mockResolvedValue([vault])
+    mocks.mockGetTokenPriceUsd.mockResolvedValue(0.5)
+    mocks.mockCalculateVaultAPRs.mockResolvedValue({
+      [vault.address]: [
+        {
+          vaultName: vault.name,
+          vaultAddress: vault.address,
+          poolType: 'yearn',
+          breakdown: {
+            apr: 10,
+            token: {
+              address: '0x00000000000000000000000000000000000000bb',
+              symbol: 'KAT',
+              decimals: 18,
+            },
+            weight: 0,
+          },
+        },
+      ],
+    })
+
+    const service = new DataCacheService()
+    const data = await service.generateVaultAPRData()
+
+    expect(data[vault.address].apr?.extra?.fixedRateKatanaRewards).toBe(1.75)
   })
 })

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -3,9 +3,11 @@ import { isAddressEqual } from 'viem'
 import { config } from '../config/index'
 import type { YearnVault } from '../types/index'
 import { YearnApiService } from './externalApis/yearnApi'
+import { KatanaPriceService } from './externalApis/katanaPriceService'
 import { YearnAprCalculator } from './aprCalcs/yearnAprCalculator'
 import { SteerPointsCalculator } from './pointsCalcs/steerPointsCalculator'
 import { logVaultAprDebug } from './aprCalcs/debugLogger'
+import { CANONICAL_KAT_ADDRESS } from './katanaRewardTokens'
 import {
   type RewardCalculatorResult,
   TokenBreakdown,
@@ -25,13 +27,36 @@ export interface APRDataCache {
 
 export type { TokenBreakdown }
 
+const ASSUMED_KAT_PRICE_USD = 0.1
+
+const FIXED_RATE_APR_AT_ASSUMED_KAT_PRICE: Record<
+  | 'yvvbETH'
+  | 'yvvbUSDC'
+  | 'yvvbUSDT'
+  | 'AUSD'
+  | 'yvvbWBTC'
+  | 'yvvbUSDS'
+  | 'yvwstETH',
+  number
+> = {
+  yvvbETH: 0.14,
+  yvvbUSDC: 0.35,
+  yvvbUSDT: 0.35,
+  AUSD: 0.35,
+  yvvbWBTC: 0.07,
+  yvvbUSDS: 0.0,
+  yvwstETH: 0.0,
+}
+
 export class DataCacheService {
   private yearnApi: YearnApiService
+  private katanaPriceService: KatanaPriceService
   private yearnAprCalculator: YearnAprCalculator
   private steerPointsCalculator: SteerPointsCalculator
 
   constructor() {
     this.yearnApi = new YearnApiService()
+    this.katanaPriceService = new KatanaPriceService()
     this.yearnAprCalculator = new YearnAprCalculator()
     this.steerPointsCalculator = new SteerPointsCalculator()
   }
@@ -52,9 +77,14 @@ export class DataCacheService {
     // Get APR data from each calculator
     const [
       yearnAPRs,
+      katanaTokenPriceUsd,
       // fixedRateAPRs
     ] = await Promise.all([
       this.yearnAprCalculator.calculateVaultAPRs(vaults),
+      this.katanaPriceService.getTokenPriceUsd(
+        config.katanaChainId,
+        CANONICAL_KAT_ADDRESS,
+      ),
       // this.yearnAprCalculator.calculateFixedRateVaultAPRs(vaults),
     ])
 
@@ -98,7 +128,10 @@ export class DataCacheService {
             reason: 'vault_results_aggregated',
           })
 
-          return [vault.address, this.aggregateVaultResults(vault, allResults)]
+          return [
+            vault.address,
+            this.aggregateVaultResults(vault, allResults, katanaTokenPriceUsd),
+          ]
         } catch (error) {
           console.error(`Error processing vault ${vault.address}:`, error)
           logVaultAprDebug({
@@ -140,6 +173,7 @@ export class DataCacheService {
   private aggregateVaultResults(
     vault: YearnVault,
     results: RewardCalculatorResult[],
+    katanaTokenPriceUsd: number,
   ): YearnVault {
     // Build new strategies array with appended data from results
     const strategiesWithRewards = (vault.strategies || []).map((strat) => {
@@ -194,8 +228,14 @@ export class DataCacheService {
       0,
     )
 
-    // Legacy fields are kept for consumer compatibility, but both programs are retired post-TGE.
-    const fixedRateFromHardcoded = 0
+    const fixedRateBaseApr =
+      FIXED_RATE_APR_AT_ASSUMED_KAT_PRICE[
+        vault.symbol as keyof typeof FIXED_RATE_APR_AT_ASSUMED_KAT_PRICE
+      ] || 0
+
+    const fixedRateFromHardcoded =
+      fixedRateBaseApr * (katanaTokenPriceUsd / ASSUMED_KAT_PRICE_USD)
+
     const vaultKatanaBonusAPY = 0
 
     const katanaNativeYield = vault.apr?.netAPR || 0

--- a/src/app/services/externalApis/katanaPriceService.test.ts
+++ b/src/app/services/externalApis/katanaPriceService.test.ts
@@ -14,11 +14,17 @@ vi.mock('axios', () => ({
   },
 }))
 
-import { KatanaPriceService, parseYDaemonPriceUsd } from './katanaPriceService'
+import {
+  KatanaPriceService,
+  parseYDaemonPriceUsd,
+  resetKatanaPriceServiceCache,
+} from './katanaPriceService'
 
 describe('KatanaPriceService', () => {
   beforeEach(() => {
+    vi.useRealTimers()
     mocks.axiosGet.mockReset()
+    resetKatanaPriceServiceCache()
   })
 
   it('returns CoinGecko price when available for the requested address', async () => {
@@ -109,6 +115,113 @@ describe('KatanaPriceService', () => {
     )
 
     expect(price).toBe(0)
+  })
+
+  it('reuses a cached price within the TTL window', async () => {
+    mocks.axiosGet.mockResolvedValueOnce({
+      data: {
+        [config.coingeckoKatanaCoinId]: {
+          usd: 1.25,
+        },
+      },
+    })
+
+    const service = new KatanaPriceService()
+    const firstPrice = await service.getTokenPriceUsd(
+      config.katanaChainId,
+      CANONICAL_KAT_ADDRESS,
+    )
+    const secondPrice = await service.getTokenPriceUsd(
+      config.katanaChainId,
+      WRAPPED_KAT_ADDRESS,
+    )
+
+    expect(firstPrice).toBe(1.25)
+    expect(secondPrice).toBe(1.25)
+    expect(mocks.axiosGet).toHaveBeenCalledTimes(1)
+  })
+
+  it('deduplicates concurrent refreshes for the same KAT price', async () => {
+    let resolveRequest: ((value: {
+      data: Record<string, { usd?: number }>
+    }) => void) | undefined
+
+    mocks.axiosGet.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRequest = resolve
+        }),
+    )
+
+    const service = new KatanaPriceService()
+    const firstRequest = service.getTokenPriceUsd(
+      config.katanaChainId,
+      CANONICAL_KAT_ADDRESS,
+    )
+    const secondRequest = service.getTokenPriceUsd(
+      config.katanaChainId,
+      WRAPPED_KAT_ADDRESS,
+    )
+
+    expect(mocks.axiosGet).toHaveBeenCalledTimes(1)
+
+    resolveRequest?.({
+      data: {
+        [config.coingeckoKatanaCoinId]: {
+          usd: 1.25,
+        },
+      },
+    })
+
+    const [firstPrice, secondPrice] = await Promise.all([
+      firstRequest,
+      secondRequest,
+    ])
+
+    expect(firstPrice).toBe(1.25)
+    expect(secondPrice).toBe(1.25)
+    expect(mocks.axiosGet).toHaveBeenCalledTimes(1)
+  })
+
+  it('serves a stale cached price when refresh fails within the stale window', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-18T09:00:00.000Z'))
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
+    mocks.axiosGet.mockResolvedValueOnce({
+      data: {
+        [config.coingeckoKatanaCoinId]: {
+          usd: 1.25,
+        },
+      },
+    })
+
+    const service = new KatanaPriceService()
+    const freshPrice = await service.getTokenPriceUsd(
+      config.katanaChainId,
+      CANONICAL_KAT_ADDRESS,
+    )
+
+    vi.setSystemTime(new Date('2026-03-18T09:01:30.000Z'))
+    mocks.axiosGet.mockRejectedValueOnce(new Error('CoinGecko rate limited'))
+    mocks.axiosGet.mockResolvedValueOnce({
+      data: {
+        [config.katanaChainId]: {},
+      },
+    })
+
+    const stalePrice = await service.getTokenPriceUsd(
+      config.katanaChainId,
+      CANONICAL_KAT_ADDRESS,
+    )
+
+    expect(freshPrice).toBe(1.25)
+    expect(stalePrice).toBe(1.25)
+    expect(mocks.axiosGet).toHaveBeenCalledTimes(3)
+
+    consoleErrorSpy.mockRestore()
   })
 })
 

--- a/src/app/services/externalApis/katanaPriceService.ts
+++ b/src/app/services/externalApis/katanaPriceService.ts
@@ -1,7 +1,11 @@
 import axios from 'axios'
 import { formatUnits } from 'viem'
 import { config } from '../../config'
-import { getKatanaPriceLookupAddresses } from '../katanaRewardTokens'
+import {
+  CANONICAL_KAT_ADDRESS,
+  getKatanaPriceLookupAddresses,
+  isKatanaRewardTokenAddress,
+} from '../katanaRewardTokens'
 
 type CoinGeckoTokenPriceResponse = Record<
   string,
@@ -13,9 +17,31 @@ type CoinGeckoTokenPriceResponse = Record<
 type YDaemonPricesChain = Record<string, Record<string, string>>
 
 const YDAEMON_PRICE_DECIMALS = 6
+const PRICE_CACHE_TTL_MS = 60_000
+const PRICE_CACHE_STALE_TTL_MS = 5 * 60_000
+
+type CachedKatanaPrice = {
+  priceUsd: number
+  freshUntil: number
+  staleUntil: number
+}
+
+const katanaPriceCache = new Map<string, CachedKatanaPrice>()
+const inFlightPriceRequests = new Map<string, Promise<number>>()
 
 const isPositiveFiniteNumber = (value: unknown): value is number =>
   typeof value === 'number' && Number.isFinite(value) && value > 0
+
+const getCacheKeyAddress = (tokenAddress: string): string => {
+  if (isKatanaRewardTokenAddress(tokenAddress)) {
+    return CANONICAL_KAT_ADDRESS.toLowerCase()
+  }
+
+  return tokenAddress.toLowerCase()
+}
+
+const getCacheKey = (chainId: number, tokenAddress: string): string =>
+  `${chainId}:${getCacheKeyAddress(tokenAddress)}`
 
 const parseYDaemonPriceUsd = (rawPrice: unknown): number => {
   if (typeof rawPrice !== 'string' || rawPrice.length === 0) {
@@ -49,6 +75,51 @@ export class KatanaPriceService {
   }
 
   async getTokenPriceUsd(
+    chainId: number,
+    tokenAddress: string,
+  ): Promise<number> {
+    const cacheKey = getCacheKey(chainId, tokenAddress)
+    const now = Date.now()
+    const cachedPrice = katanaPriceCache.get(cacheKey)
+
+    if (cachedPrice && cachedPrice.freshUntil > now) {
+      return cachedPrice.priceUsd
+    }
+
+    const inFlightRequest = inFlightPriceRequests.get(cacheKey)
+    if (inFlightRequest) {
+      return await inFlightRequest
+    }
+
+    const refreshPromise = this.fetchTokenPriceUsd(chainId, tokenAddress)
+      .then((priceUsd) => {
+        const refreshedAt = Date.now()
+
+        if (priceUsd > 0) {
+          katanaPriceCache.set(cacheKey, {
+            priceUsd,
+            freshUntil: refreshedAt + PRICE_CACHE_TTL_MS,
+            staleUntil: refreshedAt + PRICE_CACHE_STALE_TTL_MS,
+          })
+          return priceUsd
+        }
+
+        const staleCachedPrice = katanaPriceCache.get(cacheKey)
+        if (staleCachedPrice && staleCachedPrice.staleUntil > refreshedAt) {
+          return staleCachedPrice.priceUsd
+        }
+
+        return 0
+      })
+      .finally(() => {
+        inFlightPriceRequests.delete(cacheKey)
+      })
+
+    inFlightPriceRequests.set(cacheKey, refreshPromise)
+    return await refreshPromise
+  }
+
+  private async fetchTokenPriceUsd(
     chainId: number,
     tokenAddress: string,
   ): Promise<number> {
@@ -126,6 +197,11 @@ export class KatanaPriceService {
 
     return 0
   }
+}
+
+export const resetKatanaPriceServiceCache = (): void => {
+  katanaPriceCache.clear()
+  inFlightPriceRequests.clear()
 }
 
 export { parseYDaemonPriceUsd }


### PR DESCRIPTION
This PR makes an adjustment to #30  and brings back the fixed rewards but scales them by the live token price. Also protects the coingecko api key from rate limiting.