### PR TITLE
Add merkl fallback urls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ KONG_WEBHOOK_SECRET=
 # Optional (defaults shown)
 # PORT=3000
 # YDAEMON_BASE_URI=https://ydaemon.yearn.fi
+# Primary Merkl host; app code falls back to api.merkl.fr and api-merkl.angle.money
 # MERKL_BASE_URI=https://api.merkl.xyz
 # COINGECKO_BASE_URI=https://api.coingecko.com/api/v3
 # COINGECKO_KATANA_COIN_ID=katana-network-token

--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ KONG_WEBHOOK_SECRET=
 # Optional (defaults shown)
 # PORT=3000
 # YDAEMON_BASE_URI=https://ydaemon.yearn.fi
-# Primary Merkl host; app code falls back to api.merkl.fr and api-merkl.angle.money
+# Default Merkl host; public fallbacks are only used while this stays on api.merkl.xyz
 # MERKL_BASE_URI=https://api.merkl.xyz
 # COINGECKO_BASE_URI=https://api.coingecko.com/api/v3
 # COINGECKO_KATANA_COIN_ID=katana-network-token

--- a/docs/api-integration-guide.md
+++ b/docs/api-integration-guide.md
@@ -73,6 +73,11 @@ Base URL (default):
 
 - `https://api.merkl.xyz`
 
+Fallback hosts used by app code when the primary request fails:
+
+- `https://api.merkl.fr`
+- `https://api-merkl.angle.money`
+
 Docs:
 
 - HTML docs: `https://api.merkl.xyz/docs#tag/opportunities`
@@ -134,6 +139,8 @@ Notes:
 ### 2) Merkl fetch
 
 `MerklApiService.getErc20LogProcessorOpportunities()` fetches Merkl opportunities and campaign payloads.
+
+It tries the configured `MERKL_BASE_URI` first, then falls back to `https://api.merkl.fr` and `https://api-merkl.angle.money` before returning an empty result.
 
 ### 3) Blacklist filter
 

--- a/docs/api-integration-guide.md
+++ b/docs/api-integration-guide.md
@@ -73,7 +73,7 @@ Base URL (default):
 
 - `https://api.merkl.xyz`
 
-Fallback hosts used by app code when the primary request fails:
+Fallback hosts used by app code when the primary Merkl host is the default domain and that request fails:
 
 - `https://api.merkl.fr`
 - `https://api-merkl.angle.money`
@@ -140,7 +140,9 @@ Notes:
 
 `MerklApiService.getErc20LogProcessorOpportunities()` fetches Merkl opportunities and campaign payloads.
 
-It tries the configured `MERKL_BASE_URI` first, then falls back to `https://api.merkl.fr` and `https://api-merkl.angle.money` before returning an empty result.
+When `MERKL_BASE_URI` is left at the default `https://api.merkl.xyz`, it falls back to `https://api.merkl.fr` and `https://api-merkl.angle.money` before returning an empty result.
+
+If `MERKL_BASE_URI` is overridden to a custom proxy, staging host, or local mock, the service stays on that host and returns an empty result on failure.
 
 ### 3) Blacklist filter
 

--- a/scripts/debug-vault-live.ts
+++ b/scripts/debug-vault-live.ts
@@ -7,13 +7,19 @@ dotenv.config()
 
 const CHAIN_ID = Number.parseInt(process.env.KATANA_CHAIN_ID ?? '747474', 10)
 const YEARN_API_URL = process.env.YDAEMON_BASE_URI || 'https://ydaemon.yearn.fi'
+const DEFAULT_MERKL_API_URL = 'https://api.merkl.xyz'
 const MERKL_API_URL = process.env.MERKL_BASE_URI || 'https://api.merkl.xyz'
 const MERKL_FALLBACK_URLS = [
   'https://api.merkl.fr',
   'https://api-merkl.angle.money',
 ] as const
+const normalizeApiUrl = (apiUrl: string): string => apiUrl.replace(/\/+$/, '')
 const MERKL_API_URLS = Array.from(
-  new Set([MERKL_API_URL, ...MERKL_FALLBACK_URLS])
+  new Set(
+    normalizeApiUrl(MERKL_API_URL) === DEFAULT_MERKL_API_URL
+      ? [normalizeApiUrl(MERKL_API_URL), ...MERKL_FALLBACK_URLS]
+      : [normalizeApiUrl(MERKL_API_URL)]
+  )
 )
 
 const WRAPPED_KAT_ADDRESSES = [

--- a/scripts/debug-vault-live.ts
+++ b/scripts/debug-vault-live.ts
@@ -8,6 +8,13 @@ dotenv.config()
 const CHAIN_ID = Number.parseInt(process.env.KATANA_CHAIN_ID ?? '747474', 10)
 const YEARN_API_URL = process.env.YDAEMON_BASE_URI || 'https://ydaemon.yearn.fi'
 const MERKL_API_URL = process.env.MERKL_BASE_URI || 'https://api.merkl.xyz'
+const MERKL_FALLBACK_URLS = [
+  'https://api.merkl.fr',
+  'https://api-merkl.angle.money',
+] as const
+const MERKL_API_URLS = Array.from(
+  new Set([MERKL_API_URL, ...MERKL_FALLBACK_URLS])
+)
 
 const WRAPPED_KAT_ADDRESSES = [
   '0x6E9C1F88a960fE63387eb4b71BC525a9313d8461',
@@ -288,23 +295,63 @@ const applyCampaignBlacklist = (
     }
   })
 
+const normalizeMerklOpportunities = (
+  responseData: MerklOpportunity[] | { opportunities: MerklOpportunity[] }
+): MerklOpportunity[] =>
+  Array.isArray(responseData) ? responseData : responseData.opportunities || []
+
+const describeRequestError = (error: unknown): string => {
+  if (!(error instanceof Error)) {
+    return String(error)
+  }
+
+  const axiosLikeError = error as Error & {
+    code?: string
+    response?: { status?: number }
+  }
+
+  const details = [
+    axiosLikeError.code,
+    axiosLikeError.response?.status
+      ? `status ${axiosLikeError.response.status}`
+      : undefined,
+  ].filter((value): value is string => !!value)
+
+  return details.length > 0
+    ? `${error.message} (${details.join(', ')})`
+    : error.message
+}
+
 const fetchMerklOpportunities = async (): Promise<MerklOpportunity[]> => {
-  const response = await axios.get<
-    MerklOpportunity[] | { opportunities: MerklOpportunity[] }
-  >(`${MERKL_API_URL}/v4/opportunities`, {
-    params: {
-      status: 'LIVE',
-      chainId: CHAIN_ID,
-      type: 'ERC20LOGPROCESSOR',
-      campaigns: true,
-    },
-  })
+  const params = {
+    status: 'LIVE',
+    chainId: CHAIN_ID,
+    type: 'ERC20LOGPROCESSOR',
+    campaigns: true,
+  }
+  let lastError: unknown
 
-  const opportunities = Array.isArray(response.data)
-    ? response.data
-    : response.data.opportunities || []
+  for (let index = 0; index < MERKL_API_URLS.length; index += 1) {
+    const apiUrl = MERKL_API_URLS[index]
 
-  return applyCampaignBlacklist(opportunities)
+    try {
+      const response = await axios.get<
+        MerklOpportunity[] | { opportunities: MerklOpportunity[] }
+      >(`${apiUrl}/v4/opportunities`, { params })
+
+      return applyCampaignBlacklist(normalizeMerklOpportunities(response.data))
+    } catch (error) {
+      lastError = error
+
+      if (index < MERKL_API_URLS.length - 1) {
+        console.warn(
+          `Merkl request failed for ${apiUrl}; trying fallback host: ${describeRequestError(error)}`
+        )
+      }
+    }
+  }
+
+  throw lastError
 }
 
 const buildSummary = (

--- a/src/app/services/externalApis/merklApi.test.ts
+++ b/src/app/services/externalApis/merklApi.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { config } from '../../config'
 
 const mocks = vi.hoisted(() => ({
   axiosGet: vi.fn(),
@@ -21,6 +22,60 @@ describe('MerklApiService', () => {
   beforeEach(() => {
     mocks.axiosGet.mockReset()
     mocks.logVaultAprDebug.mockReset()
+  })
+
+  it('falls back to api.merkl.fr when the primary Merkl domain fails', async () => {
+    const consoleWarn = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined)
+    const primaryError = Object.assign(
+      new Error('getaddrinfo ENOTFOUND api.merkl.xyz'),
+      { code: 'ENOTFOUND' },
+    )
+    const params = {
+      name: 'yearn',
+      chainId: config.katanaChainId,
+      campaigns: true,
+    }
+    const fallbackOpportunity = {
+      chainId: 747474,
+      name: 'Yearn Opportunity',
+      tvl: 1_000_000,
+      status: 'LIVE',
+      identifier: '0x93Fec6639717b6215A48E5a72a162C50DCC40d68',
+      campaigns: [],
+    }
+
+    mocks.axiosGet
+      .mockRejectedValueOnce(primaryError)
+      .mockResolvedValueOnce({
+        data: {
+          opportunities: [fallbackOpportunity],
+        },
+      })
+
+    const service = new MerklApiService()
+    const opportunities = await service.getYearnOpportunities()
+
+    expect(opportunities).toEqual([fallbackOpportunity])
+    expect(mocks.axiosGet).toHaveBeenCalledTimes(2)
+    expect(mocks.axiosGet).toHaveBeenNthCalledWith(
+      1,
+      `${config.merklApiUrl}/v4/opportunities`,
+      { params },
+    )
+    expect(mocks.axiosGet).toHaveBeenNthCalledWith(
+      2,
+      'https://api.merkl.fr/v4/opportunities',
+      { params },
+    )
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Merkl request failed for ${config.merklApiUrl}; trying fallback host:`,
+      ),
+    )
+
+    consoleWarn.mockRestore()
   })
 
   it('logs when a blacklist removes the active APR-breakdown campaign', async () => {
@@ -94,5 +149,64 @@ describe('MerklApiService', () => {
         blacklistedAprBreakdownCampaignIds: [blacklistedCampaignId],
       }),
     )
+  })
+
+  it('returns an empty array after all Merkl hosts fail', async () => {
+    const consoleWarn = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined)
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const firstError = Object.assign(
+      new Error('getaddrinfo ENOTFOUND api.merkl.xyz'),
+      { code: 'ENOTFOUND' },
+    )
+    const secondError = Object.assign(new Error('Route not found'), {
+      response: { status: 404 },
+    })
+    const thirdError = Object.assign(new Error('Gateway timeout'), {
+      response: { status: 504 },
+    })
+    const params = {
+      status: 'LIVE',
+      chainId: config.katanaChainId,
+      type: 'ERC20_FIX_APR',
+      campaigns: true,
+    }
+
+    mocks.axiosGet
+      .mockRejectedValueOnce(firstError)
+      .mockRejectedValueOnce(secondError)
+      .mockRejectedValueOnce(thirdError)
+
+    const service = new MerklApiService()
+    const opportunities = await service.getErc20FixAprOpportunities()
+
+    expect(opportunities).toEqual([])
+    expect(mocks.axiosGet).toHaveBeenCalledTimes(3)
+    expect(mocks.axiosGet).toHaveBeenNthCalledWith(
+      1,
+      `${config.merklApiUrl}/v4/opportunities`,
+      { params },
+    )
+    expect(mocks.axiosGet).toHaveBeenNthCalledWith(
+      2,
+      'https://api.merkl.fr/v4/opportunities',
+      { params },
+    )
+    expect(mocks.axiosGet).toHaveBeenNthCalledWith(
+      3,
+      'https://api-merkl.angle.money/v4/opportunities',
+      { params },
+    )
+    expect(consoleWarn).toHaveBeenCalledTimes(2)
+    expect(consoleError).toHaveBeenCalledWith(
+      'Error fetching ERC20 Fixed APR opportunities:',
+      thirdError,
+    )
+
+    consoleWarn.mockRestore()
+    consoleError.mockRestore()
   })
 })

--- a/src/app/services/externalApis/merklApi.test.ts
+++ b/src/app/services/externalApis/merklApi.test.ts
@@ -78,6 +78,44 @@ describe('MerklApiService', () => {
     consoleWarn.mockRestore()
   })
 
+  it('does not fall back when a custom Merkl base URI is configured', async () => {
+    const consoleWarn = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined)
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const customApiUrl = 'https://merkl-proxy.internal'
+    const customError = Object.assign(new Error('Bad gateway'), {
+      response: { status: 502 },
+    })
+    const params = {
+      name: 'yearn',
+      chainId: config.katanaChainId,
+      campaigns: true,
+    }
+
+    mocks.axiosGet.mockRejectedValueOnce(customError)
+
+    const service = new MerklApiService(customApiUrl)
+    const opportunities = await service.getYearnOpportunities()
+
+    expect(opportunities).toEqual([])
+    expect(mocks.axiosGet).toHaveBeenCalledTimes(1)
+    expect(mocks.axiosGet).toHaveBeenCalledWith(
+      `${customApiUrl}/v4/opportunities`,
+      { params },
+    )
+    expect(consoleWarn).not.toHaveBeenCalled()
+    expect(consoleError).toHaveBeenCalledWith(
+      'Error fetching Yearn opportunities:',
+      customError,
+    )
+
+    consoleWarn.mockRestore()
+    consoleError.mockRestore()
+  })
+
   it('logs when a blacklist removes the active APR-breakdown campaign', async () => {
     const vaultAddress = '0x93Fec6639717b6215A48E5a72a162C50DCC40d68'
     const blacklistedCampaignId =

--- a/src/app/services/externalApis/merklApi.ts
+++ b/src/app/services/externalApis/merklApi.ts
@@ -5,6 +5,15 @@ import { isAddress } from 'viem'
 import { logVaultAprDebug } from '../aprCalcs/debugLogger'
 import { isExcludedCampaignId } from './merklBlacklist'
 
+const MERKL_FALLBACK_URLS = [
+  'https://api.merkl.fr',
+  'https://api-merkl.angle.money',
+] as const
+
+type MerklOpportunitiesResponse =
+  | MerklOpportunity[]
+  | { opportunities: MerklOpportunity[] }
+
 const extractAddressFromIdentifier = (
   identifier?: string
 ): string | undefined => {
@@ -17,10 +26,12 @@ const extractAddressFromIdentifier = (
 }
 
 export class MerklApiService {
-  private apiUrl: string
+  private apiUrls: string[]
 
   constructor() {
-    this.apiUrl = config.merklApiUrl
+    this.apiUrls = Array.from(
+      new Set([config.merklApiUrl, ...MERKL_FALLBACK_URLS])
+    )
   }
 
   private filterCampaigns(
@@ -83,24 +94,74 @@ export class MerklApiService {
     })
   }
 
+  private normalizeOpportunities(
+    responseData: MerklOpportunitiesResponse,
+  ): MerklOpportunity[] {
+    return Array.isArray(responseData)
+      ? responseData
+      : responseData.opportunities || []
+  }
+
+  private describeRequestError(error: unknown): string {
+    if (!(error instanceof Error)) {
+      return String(error)
+    }
+
+    const axiosLikeError = error as Error & {
+      code?: string
+      response?: { status?: number }
+    }
+
+    const details = [
+      axiosLikeError.code,
+      axiosLikeError.response?.status
+        ? `status ${axiosLikeError.response.status}`
+        : undefined,
+    ].filter((value): value is string => !!value)
+
+    return details.length > 0
+      ? `${error.message} (${details.join(', ')})`
+      : error.message
+  }
+
+  private async fetchOpportunities(
+    params: Record<string, boolean | number | string>,
+  ): Promise<MerklOpportunity[]> {
+    let lastError: unknown
+
+    for (let index = 0; index < this.apiUrls.length; index += 1) {
+      const apiUrl = this.apiUrls[index]
+
+      try {
+        const response = await axios.get<MerklOpportunitiesResponse>(
+          `${apiUrl}/v4/opportunities`,
+          { params },
+        )
+
+        return this.normalizeOpportunities(response.data)
+      } catch (error) {
+        lastError = error
+
+        if (index < this.apiUrls.length - 1) {
+          console.warn(
+            `Merkl request failed for ${apiUrl}; trying fallback host: ${this.describeRequestError(error)}`
+          )
+        }
+      }
+    }
+
+    throw lastError
+  }
+
   async getSushiOpportunities(): Promise<MerklOpportunity[]> {
     try {
-      const url: string = `${this.apiUrl}/v4/opportunities`
       const params = {
         name: 'sushi',
         chainId: config.katanaChainId,
         campaigns: true,
       }
 
-      const response = await axios.get<
-        MerklOpportunity[] | { opportunities: MerklOpportunity[] }
-      >(url, { params })
-
-      // The response is an array directly
-      const opportunities: MerklOpportunity[] = Array.isArray(response.data)
-        ? response.data
-        : response.data.opportunities || []
-
+      const opportunities = await this.fetchOpportunities(params)
       return this.filterCampaigns(opportunities)
     } catch (error) {
       console.error('Error fetching Sushi opportunities:', error)
@@ -110,22 +171,13 @@ export class MerklApiService {
 
   async getMorphoOpportunities(): Promise<MerklOpportunity[]> {
     try {
-      const url: string = `${this.apiUrl}/v4/opportunities`
       const params = {
         name: 'morpho',
         chainId: config.katanaChainId,
         campaigns: true,
       }
 
-      const response = await axios.get<
-        MerklOpportunity[] | { opportunities: MerklOpportunity[] }
-      >(url, { params })
-
-      // The response is an array directly
-      const opportunities: MerklOpportunity[] = Array.isArray(response.data)
-        ? response.data
-        : response.data.opportunities || []
-
+      const opportunities = await this.fetchOpportunities(params)
       return this.filterCampaigns(opportunities)
     } catch (error) {
       console.error('Error fetching Morpho opportunities:', error)
@@ -145,22 +197,13 @@ export class MerklApiService {
    */
   async getYearnOpportunities(): Promise<MerklOpportunity[]> {
     try {
-      const url: string = `${this.apiUrl}/v4/opportunities`
       const params = {
         name: 'yearn',
         chainId: config.katanaChainId,
         campaigns: true,
       }
 
-      const response = await axios.get<
-        MerklOpportunity[] | { opportunities: MerklOpportunity[] }
-      >(url, { params })
-
-      // The response is an array directly
-      const opportunities: MerklOpportunity[] = Array.isArray(response.data)
-        ? response.data
-        : response.data.opportunities || []
-
+      const opportunities = await this.fetchOpportunities(params)
       return this.filterCampaigns(opportunities)
     } catch (error) {
       console.error('Error fetching Yearn opportunities:', error)
@@ -184,7 +227,6 @@ export class MerklApiService {
    */
   async getErc20LogProcessorOpportunities(): Promise<MerklOpportunity[]> {
     try {
-      const url: string = `${this.apiUrl}/v4/opportunities`
       const params = {
         status: 'LIVE',
         chainId: config.katanaChainId,
@@ -192,15 +234,7 @@ export class MerklApiService {
         campaigns: true,
       }
 
-      const response = await axios.get<
-        MerklOpportunity[] | { opportunities: MerklOpportunity[] }
-      >(url, { params })
-
-      // The response is an array directly
-      const opportunities: MerklOpportunity[] = Array.isArray(response.data)
-        ? response.data
-        : response.data.opportunities || []
-
+      const opportunities = await this.fetchOpportunities(params)
       const filteredOpportunities = this.filterCampaigns(opportunities)
       for (const opportunity of filteredOpportunities) {
         const vaultAddress = extractAddressFromIdentifier(
@@ -242,7 +276,6 @@ export class MerklApiService {
    */
   async getErc20FixAprOpportunities(): Promise<MerklOpportunity[]> {
     try {
-      const url: string = `${this.apiUrl}/v4/opportunities`
       const params = {
         status: 'LIVE',
         chainId: config.katanaChainId,
@@ -250,15 +283,7 @@ export class MerklApiService {
         campaigns: true,
       }
 
-      const response = await axios.get<
-        MerklOpportunity[] | { opportunities: MerklOpportunity[] }
-      >(url, { params })
-
-      // The response is an array directly
-      const opportunities: MerklOpportunity[] = Array.isArray(response.data)
-        ? response.data
-        : response.data.opportunities || []
-
+      const opportunities = await this.fetchOpportunities(params)
       const filteredOpportunities = this.filterCampaigns(opportunities)
       for (const opportunity of filteredOpportunities) {
         const vaultAddress = extractAddressFromIdentifier(
@@ -282,7 +307,7 @@ export class MerklApiService {
 
       return filteredOpportunities
     } catch (error) {
-      console.error('Error fetching ERC20 Log Processor opportunities:', error)
+      console.error('Error fetching ERC20 Fixed APR opportunities:', error)
       return []
     }
   }

--- a/src/app/services/externalApis/merklApi.ts
+++ b/src/app/services/externalApis/merklApi.ts
@@ -5,6 +5,7 @@ import { isAddress } from 'viem'
 import { logVaultAprDebug } from '../aprCalcs/debugLogger'
 import { isExcludedCampaignId } from './merklBlacklist'
 
+const DEFAULT_MERKL_API_URL = 'https://api.merkl.xyz'
 const MERKL_FALLBACK_URLS = [
   'https://api.merkl.fr',
   'https://api-merkl.angle.money',
@@ -25,13 +26,17 @@ const extractAddressFromIdentifier = (
   return isAddress(candidate) ? candidate : undefined
 }
 
+const normalizeApiUrl = (apiUrl: string): string => apiUrl.replace(/\/+$/, '')
+
 export class MerklApiService {
   private apiUrls: string[]
 
-  constructor() {
-    this.apiUrls = Array.from(
-      new Set([config.merklApiUrl, ...MERKL_FALLBACK_URLS])
-    )
+  constructor(apiUrl: string = config.merklApiUrl) {
+    const primaryApiUrl = normalizeApiUrl(apiUrl)
+    this.apiUrls =
+      primaryApiUrl === DEFAULT_MERKL_API_URL
+        ? Array.from(new Set([primaryApiUrl, ...MERKL_FALLBACK_URLS]))
+        : [primaryApiUrl]
   }
 
   private filterCampaigns(


### PR DESCRIPTION
## Title
Add resilient Merkl API fallback hosts for default base URL

## Summary
This PR improves reliability of Merkl opportunity fetching by adding automatic fallback hosts when the default Merkl domain is unavailable. It keeps custom Merkl base URLs strict (no fallback) so proxy/staging/local setups continue to behave predictably.

## What changed
- Added fallback host support in `MerklApiService`:
  - Primary: `https://api.merkl.xyz`
  - Fallbacks: `https://api.merkl.fr`, `https://api-merkl.angle.money`
- Fallbacks are only used when `MERKL_BASE_URI` is still the default `api.merkl.xyz`.
- Refactored shared request handling:
  - Centralized opportunities response normalization (array vs object shape).
  - Added request error formatting for clearer fallback warnings.
  - Reused one fetch path across Sushi, Morpho, Yearn, ERC20LOGPROCESSOR, and ERC20_FIX_APR queries.
- Corrected fixed APR error log label to match method behavior.
- Added/updated tests covering:
  - Successful fallback from primary to first fallback host.
  - No fallback behavior for custom `MERKL_BASE_URI`.
  - Exhausted fallback chain returns empty result and logs final error.
- Updated debug script to mirror production fallback behavior.
- Updated API integration docs and `.env` example comments to document fallback rules.

## Behavioral impact
- Production-like default configuration is more resilient to Merkl host outages/DNS issues.
- Custom configured Merkl hosts remain isolated and do not fan out to public fallback hosts.

## Testing
- Ran targeted tests:
  - `bun run test:run src/app/services/externalApis/merklApi.test.ts`
- Result:
  - 1 test file passed
  - 4 tests passed

## Notes for reviewers
- Net diff vs `main`:
  - 5 files changed
  - 314 insertions, 69 deletions
- Main logic changes are concentrated in Merkl API fetching and fallback orchestration; docs and debug tooling were updated to stay aligned.

- To confirm this PR is working, there should be no console errors when running locally, and `katanaAppRewards` should be showing correct values and not 0s