### PR TITLE
Feat/replace axios with fetch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,6 @@
       "dependencies": {
         "@types/lodash": "^4.17.20",
         "@wagmi/core": "^2.14.7",
-        "axios": "^1.7.9",
         "dotenv": "^16.4.7",
         "lodash": "^4.17.21",
         "next": "15.3.8",
@@ -431,13 +430,9 @@
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
 
-    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
-
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
     "axe-core": ["axe-core@4.10.3", "", {}, "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg=="],
-
-    "axios": ["axios@1.10.0", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.0", "proxy-from-env": "^1.1.0" } }, "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -491,8 +486,6 @@
 
     "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
 
-    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
-
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
@@ -520,8 +513,6 @@
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
-
-    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -625,11 +616,7 @@
 
     "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
 
-    "follow-redirects": ["follow-redirects@1.15.9", "", {}, "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="],
-
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
-
-    "form-data": ["form-data@4.0.3", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -885,10 +872,6 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
-    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
-
-    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
-
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
@@ -964,8 +947,6 @@
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
-
-    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@types/lodash": "^4.17.20",
     "@wagmi/core": "^2.14.7",
-    "axios": "^1.7.9",
     "dotenv": "^16.4.7",
     "lodash": "^4.17.21",
     "next": "15.3.8",

--- a/scripts/debug-vault-live.ts
+++ b/scripts/debug-vault-live.ts
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import dotenv from 'dotenv'
 import { isAddress } from 'viem'
 import { isExcludedCampaignId } from '../src/app/services/externalApis/merklBlacklist'
@@ -271,11 +270,13 @@ const fetchYearnVaults = async (): Promise<YearnVault[]> => {
     limit: '2500',
   })
 
-  const response = await axios.get<YearnVault[]>(
-    `${YEARN_API_URL}/vaults/katana?${params}`
-  )
+  const response = await fetch(`${YEARN_API_URL}/vaults/katana?${params}`)
 
-  return response.data || []
+  if (!response.ok) {
+    throw new Error(`HTTP error fetching Yearn vaults: ${response.status}`)
+  }
+
+  return ((await response.json()) as YearnVault[]) || []
 }
 
 const applyCampaignBlacklist = (
@@ -310,15 +311,13 @@ const describeRequestError = (error: unknown): string => {
     return String(error)
   }
 
-  const axiosLikeError = error as Error & {
-    code?: string
-    response?: { status?: number }
+  const fetchLikeError = error as Error & {
+    status?: number
   }
 
   const details = [
-    axiosLikeError.code,
-    axiosLikeError.response?.status
-      ? `status ${axiosLikeError.response.status}`
+    fetchLikeError.status
+      ? `status ${fetchLikeError.status}`
       : undefined,
   ].filter((value): value is string => !!value)
 
@@ -328,23 +327,34 @@ const describeRequestError = (error: unknown): string => {
 }
 
 const fetchMerklOpportunities = async (): Promise<MerklOpportunity[]> => {
-  const params = {
+  const searchParams = new URLSearchParams({
     status: 'LIVE',
-    chainId: CHAIN_ID,
+    chainId: String(CHAIN_ID),
     type: 'ERC20LOGPROCESSOR',
-    campaigns: true,
-  }
+    campaigns: 'true',
+  })
   let lastError: unknown
 
   for (let index = 0; index < MERKL_API_URLS.length; index += 1) {
     const apiUrl = MERKL_API_URLS[index]
 
     try {
-      const response = await axios.get<
-        MerklOpportunity[] | { opportunities: MerklOpportunity[] }
-      >(`${apiUrl}/v4/opportunities`, { params })
+      const response = await fetch(
+        `${apiUrl}/v4/opportunities?${searchParams}`,
+      )
 
-      return applyCampaignBlacklist(normalizeMerklOpportunities(response.data))
+      if (!response.ok) {
+        const httpError = Object.assign(
+          new Error(`HTTP error fetching Merkl opportunities`),
+          { status: response.status },
+        )
+        throw httpError
+      }
+
+      const data = (await response.json()) as
+        | MerklOpportunity[]
+        | { opportunities: MerklOpportunity[] }
+      return applyCampaignBlacklist(normalizeMerklOpportunities(data))
     } catch (error) {
       lastError = error
 

--- a/src/app/services/externalApis/katanaPriceService.test.ts
+++ b/src/app/services/externalApis/katanaPriceService.test.ts
@@ -6,14 +6,10 @@ const LEGACY_KAT_ADDRESS = '0x0161A31702d6CF715aaa912d64c6A190FD0093aa'
 const WRAPPED_KAT_ADDRESS = '0x6E9C1F88a960fE63387eb4b71BC525a9313d8461'
 
 const mocks = vi.hoisted(() => ({
-  axiosGet: vi.fn(),
+  fetchGet: vi.fn(),
 }))
 
-vi.mock('axios', () => ({
-  default: {
-    get: mocks.axiosGet,
-  },
-}))
+vi.stubGlobal('fetch', mocks.fetchGet)
 
 import {
   KatanaPriceService,
@@ -21,21 +17,35 @@ import {
   resetKatanaPriceServiceCache,
 } from './katanaPriceService'
 
+const makeOkResponse = (data: unknown) =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(data),
+  })
+
+const makeErrorResponse = (status: number) =>
+  Promise.resolve({
+    ok: false,
+    status,
+    json: () => Promise.reject(new Error('error body')),
+  })
+
 describe('KatanaPriceService', () => {
   beforeEach(() => {
     vi.useRealTimers()
-    mocks.axiosGet.mockReset()
+    mocks.fetchGet.mockReset()
     resetKatanaPriceServiceCache()
   })
 
   it('returns yDaemon price when available for the canonical address', async () => {
-    mocks.axiosGet.mockResolvedValueOnce({
-      data: {
+    mocks.fetchGet.mockImplementationOnce(() =>
+      makeOkResponse({
         [config.katanaChainId]: {
           [CANONICAL_KAT_ADDRESS.toLowerCase()]: '1250000',
         },
-      },
-    })
+      }),
+    )
 
     const service = new KatanaPriceService()
     const price = await service.getTokenPriceUsd(
@@ -44,20 +54,20 @@ describe('KatanaPriceService', () => {
     )
 
     expect(price).toBe(1.25)
-    expect(mocks.axiosGet).toHaveBeenCalledWith(
+    expect(mocks.fetchGet).toHaveBeenCalledWith(
       `${config.yearnApiUrl}/prices/all`,
     )
   })
 
   it('falls back to CoinGecko when yDaemon cannot serve a price', async () => {
-    mocks.axiosGet.mockResolvedValueOnce({ data: {} })
-    mocks.axiosGet.mockResolvedValueOnce({
-      data: {
+    mocks.fetchGet.mockImplementationOnce(() => makeOkResponse({}))
+    mocks.fetchGet.mockImplementationOnce(() =>
+      makeOkResponse({
         [config.coingeckoKatanaCoinId]: {
           usd: 1.25,
         },
-      },
-    })
+      }),
+    )
 
     const service = new KatanaPriceService()
     const price = await service.getTokenPriceUsd(
@@ -66,26 +76,26 @@ describe('KatanaPriceService', () => {
     )
 
     expect(price).toBe(1.25)
-    expect(mocks.axiosGet).toHaveBeenNthCalledWith(
+    expect(mocks.fetchGet).toHaveBeenNthCalledWith(
       2,
-      `${config.coingeckoApiUrl}/simple/price`,
-      expect.objectContaining({
-        params: {
-          ids: config.coingeckoKatanaCoinId,
-          vs_currencies: 'usd',
-        },
-      }),
+      expect.stringContaining(`${config.coingeckoApiUrl}/simple/price`),
+      expect.objectContaining({ headers: undefined }),
+    )
+    expect(mocks.fetchGet).toHaveBeenNthCalledWith(
+      2,
+      expect.stringMatching(/ids=katana-network-token/),
+      expect.anything(),
     )
   })
 
   it('aliases the legacy KAT address to the canonical KAT yDaemon price', async () => {
-    mocks.axiosGet.mockResolvedValueOnce({
-      data: {
+    mocks.fetchGet.mockImplementationOnce(() =>
+      makeOkResponse({
         [config.katanaChainId]: {
           [CANONICAL_KAT_ADDRESS.toLowerCase()]: '2500000',
         },
-      },
-    })
+      }),
+    )
 
     const service = new KatanaPriceService()
     const price = await service.getTokenPriceUsd(
@@ -94,19 +104,19 @@ describe('KatanaPriceService', () => {
     )
 
     expect(price).toBe(2.5)
-    expect(mocks.axiosGet).toHaveBeenCalledWith(
+    expect(mocks.fetchGet).toHaveBeenCalledWith(
       `${config.yearnApiUrl}/prices/all`,
     )
   })
 
   it('aliases wrapped KAT addresses to the canonical KAT yDaemon price', async () => {
-    mocks.axiosGet.mockResolvedValueOnce({
-      data: {
+    mocks.fetchGet.mockImplementationOnce(() =>
+      makeOkResponse({
         [config.katanaChainId]: {
           [CANONICAL_KAT_ADDRESS.toLowerCase()]: '2500000',
         },
-      },
-    })
+      }),
+    )
 
     const service = new KatanaPriceService()
     const price = await service.getTokenPriceUsd(
@@ -115,16 +125,14 @@ describe('KatanaPriceService', () => {
     )
 
     expect(price).toBe(2.5)
-    expect(mocks.axiosGet).toHaveBeenCalledWith(
+    expect(mocks.fetchGet).toHaveBeenCalledWith(
       `${config.yearnApiUrl}/prices/all`,
     )
   })
 
   it('returns 0 when both yDaemon and CoinGecko fail to provide a price', async () => {
-    mocks.axiosGet.mockResolvedValueOnce({ data: {} })
-    mocks.axiosGet.mockResolvedValueOnce({
-      data: {},
-    })
+    mocks.fetchGet.mockImplementationOnce(() => makeOkResponse({}))
+    mocks.fetchGet.mockImplementationOnce(() => makeOkResponse({}))
 
     const service = new KatanaPriceService()
     const price = await service.getTokenPriceUsd(
@@ -136,13 +144,13 @@ describe('KatanaPriceService', () => {
   })
 
   it('reuses a cached price within the TTL window', async () => {
-    mocks.axiosGet.mockResolvedValueOnce({
-      data: {
+    mocks.fetchGet.mockImplementationOnce(() =>
+      makeOkResponse({
         [config.katanaChainId]: {
           [CANONICAL_KAT_ADDRESS.toLowerCase()]: '1250000',
         },
-      },
-    })
+      }),
+    )
 
     const service = new KatanaPriceService()
     const firstPrice = await service.getTokenPriceUsd(
@@ -156,15 +164,15 @@ describe('KatanaPriceService', () => {
 
     expect(firstPrice).toBe(1.25)
     expect(secondPrice).toBe(1.25)
-    expect(mocks.axiosGet).toHaveBeenCalledTimes(1)
+    expect(mocks.fetchGet).toHaveBeenCalledTimes(1)
   })
 
   it('deduplicates concurrent refreshes for the same KAT price', async () => {
-    let resolveRequest: ((value: {
-      data: Record<string, Record<string, string>>
-    }) => void) | undefined
+    let resolveRequest:
+      | ((value: { ok: boolean; status: number; json: () => Promise<unknown> }) => void)
+      | undefined
 
-    mocks.axiosGet.mockImplementationOnce(
+    mocks.fetchGet.mockImplementationOnce(
       () =>
         new Promise((resolve) => {
           resolveRequest = resolve
@@ -181,14 +189,17 @@ describe('KatanaPriceService', () => {
       WRAPPED_KAT_ADDRESS,
     )
 
-    expect(mocks.axiosGet).toHaveBeenCalledTimes(1)
+    expect(mocks.fetchGet).toHaveBeenCalledTimes(1)
 
-    resolveRequest?.({
-      data: {
-        [config.katanaChainId]: {
-          [CANONICAL_KAT_ADDRESS.toLowerCase()]: '1250000',
-        },
+    const responseData = {
+      [config.katanaChainId]: {
+        [CANONICAL_KAT_ADDRESS.toLowerCase()]: '1250000',
       },
+    }
+    resolveRequest?.({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(responseData),
     })
 
     const [firstPrice, secondPrice] = await Promise.all([
@@ -198,7 +209,7 @@ describe('KatanaPriceService', () => {
 
     expect(firstPrice).toBe(1.25)
     expect(secondPrice).toBe(1.25)
-    expect(mocks.axiosGet).toHaveBeenCalledTimes(1)
+    expect(mocks.fetchGet).toHaveBeenCalledTimes(1)
   })
 
   it('serves a stale cached price when refresh fails within the stale window', async () => {
@@ -208,13 +219,13 @@ describe('KatanaPriceService', () => {
       .spyOn(console, 'error')
       .mockImplementation(() => undefined)
 
-    mocks.axiosGet.mockResolvedValueOnce({
-      data: {
+    mocks.fetchGet.mockImplementationOnce(() =>
+      makeOkResponse({
         [config.katanaChainId]: {
           [CANONICAL_KAT_ADDRESS.toLowerCase()]: '1250000',
         },
-      },
-    })
+      }),
+    )
 
     const service = new KatanaPriceService()
     const freshPrice = await service.getTokenPriceUsd(
@@ -223,10 +234,8 @@ describe('KatanaPriceService', () => {
     )
 
     vi.setSystemTime(new Date('2026-03-18T09:01:30.000Z'))
-    mocks.axiosGet.mockRejectedValueOnce(new Error('yDaemon unavailable'))
-    mocks.axiosGet.mockResolvedValueOnce({
-      data: {},
-    })
+    mocks.fetchGet.mockRejectedValueOnce(new Error('yDaemon unavailable'))
+    mocks.fetchGet.mockImplementationOnce(() => makeOkResponse({}))
 
     const stalePrice = await service.getTokenPriceUsd(
       config.katanaChainId,
@@ -235,7 +244,7 @@ describe('KatanaPriceService', () => {
 
     expect(freshPrice).toBe(1.25)
     expect(stalePrice).toBe(1.25)
-    expect(mocks.axiosGet).toHaveBeenCalledTimes(3)
+    expect(mocks.fetchGet).toHaveBeenCalledTimes(3)
 
     consoleErrorSpy.mockRestore()
   })

--- a/src/app/services/externalApis/katanaPriceService.test.ts
+++ b/src/app/services/externalApis/katanaPriceService.test.ts
@@ -24,13 +24,6 @@ const makeOkResponse = (data: unknown) =>
     json: () => Promise.resolve(data),
   })
 
-const makeErrorResponse = (status: number) =>
-  Promise.resolve({
-    ok: false,
-    status,
-    json: () => Promise.reject(new Error('error body')),
-  })
-
 describe('KatanaPriceService', () => {
   beforeEach(() => {
     vi.useRealTimers()

--- a/src/app/services/externalApis/katanaPriceService.ts
+++ b/src/app/services/externalApis/katanaPriceService.ts
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import { formatUnits } from 'viem'
 import { config } from '../../config'
 import {
@@ -140,18 +139,23 @@ export class KatanaPriceService {
 
   private async getCoinGeckoPriceUsd(): Promise<number> {
     try {
-      const response = await axios.get<CoinGeckoTokenPriceResponse>(
-        `${this.coingeckoApiUrl}/simple/price`,
+      const params = new URLSearchParams({
+        ids: this.coingeckoKatanaCoinId,
+        vs_currencies: 'usd',
+      })
+      const response = await fetch(
+        `${this.coingeckoApiUrl}/simple/price?${params}`,
         {
-          params: {
-            ids: this.coingeckoKatanaCoinId,
-            vs_currencies: 'usd',
-          },
           headers: this.coinGeckoHeaders,
         },
       )
 
-      const price = response.data?.[this.coingeckoKatanaCoinId]?.usd
+      if (!response.ok) {
+        throw new Error(`HTTP error fetching CoinGecko price: ${response.status}`)
+      }
+
+      const data = (await response.json()) as CoinGeckoTokenPriceResponse
+      const price = data?.[this.coingeckoKatanaCoinId]?.usd
       if (isPositiveFiniteNumber(price)) {
         return price
       }
@@ -167,10 +171,14 @@ export class KatanaPriceService {
     addresses: string[],
   ): Promise<number> {
     try {
-      const response = await axios.get<YDaemonPricesChain>(
-        `${this.yearnApiUrl}/prices/all`,
-      )
-      const chainPrices = response.data?.[String(chainId)]
+      const response = await fetch(`${this.yearnApiUrl}/prices/all`)
+
+      if (!response.ok) {
+        throw new Error(`HTTP error fetching yDaemon prices: ${response.status}`)
+      }
+
+      const data = (await response.json()) as YDaemonPricesChain
+      const chainPrices = data?.[String(chainId)]
 
       if (!chainPrices) {
         return 0

--- a/src/app/services/externalApis/merklApi.test.ts
+++ b/src/app/services/externalApis/merklApi.test.ts
@@ -2,15 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { config } from '../../config'
 
 const mocks = vi.hoisted(() => ({
-  axiosGet: vi.fn(),
+  fetchGet: vi.fn(),
   logVaultAprDebug: vi.fn(),
 }))
 
-vi.mock('axios', () => ({
-  default: {
-    get: mocks.axiosGet,
-  },
-}))
+vi.stubGlobal('fetch', mocks.fetchGet)
 
 vi.mock('../aprCalcs/debugLogger', () => ({
   logVaultAprDebug: mocks.logVaultAprDebug,
@@ -18,9 +14,23 @@ vi.mock('../aprCalcs/debugLogger', () => ({
 
 import { MerklApiService } from './merklApi'
 
+const makeOkResponse = (data: unknown) =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(data),
+  })
+
+const makeErrorResponse = (status: number) =>
+  Promise.resolve({
+    ok: false,
+    status,
+    json: () => Promise.reject(new Error('error body')),
+  })
+
 describe('MerklApiService', () => {
   beforeEach(() => {
-    mocks.axiosGet.mockReset()
+    mocks.fetchGet.mockReset()
     mocks.logVaultAprDebug.mockReset()
   })
 
@@ -32,11 +42,6 @@ describe('MerklApiService', () => {
       new Error('getaddrinfo ENOTFOUND api.merkl.xyz'),
       { code: 'ENOTFOUND' },
     )
-    const params = {
-      name: 'yearn',
-      chainId: config.katanaChainId,
-      campaigns: true,
-    }
     const fallbackOpportunity = {
       chainId: 747474,
       name: 'Yearn Opportunity',
@@ -46,26 +51,24 @@ describe('MerklApiService', () => {
       campaigns: [],
     }
 
-    mocks.axiosGet.mockRejectedValueOnce(primaryError).mockResolvedValueOnce({
-      data: {
-        opportunities: [fallbackOpportunity],
-      },
-    })
+    mocks.fetchGet
+      .mockRejectedValueOnce(primaryError)
+      .mockImplementationOnce(() =>
+        makeOkResponse({ opportunities: [fallbackOpportunity] }),
+      )
 
     const service = new MerklApiService()
     const opportunities = await service.getYearnOpportunities()
 
     expect(opportunities).toEqual([fallbackOpportunity])
-    expect(mocks.axiosGet).toHaveBeenCalledTimes(2)
-    expect(mocks.axiosGet).toHaveBeenNthCalledWith(
+    expect(mocks.fetchGet).toHaveBeenCalledTimes(2)
+    expect(mocks.fetchGet).toHaveBeenNthCalledWith(
       1,
-      `${config.merklApiUrl}/v4/opportunities`,
-      { params },
+      expect.stringContaining(`${config.merklApiUrl}/v4/opportunities`),
     )
-    expect(mocks.axiosGet).toHaveBeenNthCalledWith(
+    expect(mocks.fetchGet).toHaveBeenNthCalledWith(
       2,
-      'https://api.merkl.fr/v4/opportunities',
-      { params },
+      expect.stringContaining('https://api.merkl.fr/v4/opportunities'),
     )
     expect(consoleWarn).toHaveBeenCalledWith(
       expect.stringContaining(
@@ -84,30 +87,21 @@ describe('MerklApiService', () => {
       .spyOn(console, 'error')
       .mockImplementation(() => undefined)
     const customApiUrl = 'https://merkl-proxy.internal'
-    const customError = Object.assign(new Error('Bad gateway'), {
-      response: { status: 502 },
-    })
-    const params = {
-      name: 'yearn',
-      chainId: config.katanaChainId,
-      campaigns: true,
-    }
 
-    mocks.axiosGet.mockRejectedValueOnce(customError)
+    mocks.fetchGet.mockImplementationOnce(() => makeErrorResponse(502))
 
     const service = new MerklApiService(customApiUrl)
     const opportunities = await service.getYearnOpportunities()
 
     expect(opportunities).toEqual([])
-    expect(mocks.axiosGet).toHaveBeenCalledTimes(1)
-    expect(mocks.axiosGet).toHaveBeenCalledWith(
-      `${customApiUrl}/v4/opportunities`,
-      { params },
+    expect(mocks.fetchGet).toHaveBeenCalledTimes(1)
+    expect(mocks.fetchGet).toHaveBeenCalledWith(
+      expect.stringContaining(`${customApiUrl}/v4/opportunities`),
     )
     expect(consoleWarn).not.toHaveBeenCalled()
     expect(consoleError).toHaveBeenCalledWith(
       'Error fetching Yearn opportunities:',
-      customError,
+      expect.any(Error),
     )
 
     consoleWarn.mockRestore()
@@ -115,21 +109,16 @@ describe('MerklApiService', () => {
   })
 
   it('queries sushiswap opportunities using the live Merkl name filter', async () => {
-    mocks.axiosGet.mockResolvedValue({
-      data: [],
-    })
+    mocks.fetchGet.mockImplementation(() => makeOkResponse([]))
 
     const service = new MerklApiService()
     await service.getSushiOpportunities()
 
-    expect(mocks.axiosGet).toHaveBeenCalledWith(
-      expect.stringContaining('/v4/opportunities'),
-      expect.objectContaining({
-        params: expect.objectContaining({
-          name: 'sushiswap',
-          campaigns: true,
-        }),
-      }),
+    expect(mocks.fetchGet).toHaveBeenCalledWith(
+      expect.stringMatching(/\/v4\/opportunities\?.*name=sushiswap/),
+    )
+    expect(mocks.fetchGet).toHaveBeenCalledWith(
+      expect.stringMatching(/\/v4\/opportunities\?.*campaigns=true/),
     )
   })
 
@@ -138,8 +127,8 @@ describe('MerklApiService', () => {
     const blacklistedCampaignId =
       '0xc5a22d022154d5c64ff14b2f4071f134eb83cf159f9f846ad0ba0908a755e86d'
 
-    mocks.axiosGet.mockResolvedValue({
-      data: [
+    mocks.fetchGet.mockImplementation(() =>
+      makeOkResponse([
         {
           chainId: 747474,
           name: 'AUSD Opportunity',
@@ -182,8 +171,8 @@ describe('MerklApiService', () => {
             ],
           },
         },
-      ],
-    })
+      ]),
+    )
 
     const service = new MerklApiService()
     const opportunities = await service.getErc20LogProcessorOpportunities()
@@ -217,48 +206,33 @@ describe('MerklApiService', () => {
       new Error('getaddrinfo ENOTFOUND api.merkl.xyz'),
       { code: 'ENOTFOUND' },
     )
-    const secondError = Object.assign(new Error('Route not found'), {
-      response: { status: 404 },
-    })
-    const thirdError = Object.assign(new Error('Gateway timeout'), {
-      response: { status: 504 },
-    })
-    const params = {
-      status: 'LIVE',
-      chainId: config.katanaChainId,
-      type: 'ERC20_FIX_APR',
-      campaigns: true,
-    }
 
-    mocks.axiosGet
+    mocks.fetchGet
       .mockRejectedValueOnce(firstError)
-      .mockRejectedValueOnce(secondError)
-      .mockRejectedValueOnce(thirdError)
+      .mockImplementationOnce(() => makeErrorResponse(404))
+      .mockImplementationOnce(() => makeErrorResponse(504))
 
     const service = new MerklApiService()
     const opportunities = await service.getErc20FixAprOpportunities()
 
     expect(opportunities).toEqual([])
-    expect(mocks.axiosGet).toHaveBeenCalledTimes(3)
-    expect(mocks.axiosGet).toHaveBeenNthCalledWith(
+    expect(mocks.fetchGet).toHaveBeenCalledTimes(3)
+    expect(mocks.fetchGet).toHaveBeenNthCalledWith(
       1,
-      `${config.merklApiUrl}/v4/opportunities`,
-      { params },
+      expect.stringContaining(`${config.merklApiUrl}/v4/opportunities`),
     )
-    expect(mocks.axiosGet).toHaveBeenNthCalledWith(
+    expect(mocks.fetchGet).toHaveBeenNthCalledWith(
       2,
-      'https://api.merkl.fr/v4/opportunities',
-      { params },
+      expect.stringContaining('https://api.merkl.fr/v4/opportunities'),
     )
-    expect(mocks.axiosGet).toHaveBeenNthCalledWith(
+    expect(mocks.fetchGet).toHaveBeenNthCalledWith(
       3,
-      'https://api-merkl.angle.money/v4/opportunities',
-      { params },
+      expect.stringContaining('https://api-merkl.angle.money/v4/opportunities'),
     )
     expect(consoleWarn).toHaveBeenCalledTimes(2)
     expect(consoleError).toHaveBeenCalledWith(
       'Error fetching ERC20 Fixed APR opportunities:',
-      thirdError,
+      expect.any(Error),
     )
 
     consoleWarn.mockRestore()

--- a/src/app/services/externalApis/merklApi.ts
+++ b/src/app/services/externalApis/merklApi.ts
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import { config } from '../../config'
 import type { MerklOpportunity } from '../../types'
 import { isAddress } from 'viem'
@@ -112,15 +111,13 @@ export class MerklApiService {
       return String(error)
     }
 
-    const axiosLikeError = error as Error & {
-      code?: string
-      response?: { status?: number }
+    const fetchLikeError = error as Error & {
+      status?: number
     }
 
     const details = [
-      axiosLikeError.code,
-      axiosLikeError.response?.status
-        ? `status ${axiosLikeError.response.status}`
+      fetchLikeError.status
+        ? `status ${fetchLikeError.status}`
         : undefined,
     ].filter((value): value is string => !!value)
 
@@ -138,12 +135,23 @@ export class MerklApiService {
       const apiUrl = this.apiUrls[index]
 
       try {
-        const response = await axios.get<MerklOpportunitiesResponse>(
-          `${apiUrl}/v4/opportunities`,
-          { params },
+        const searchParams = new URLSearchParams(
+          Object.entries(params).map(([k, v]) => [k, String(v)]),
+        )
+        const response = await fetch(
+          `${apiUrl}/v4/opportunities?${searchParams}`,
         )
 
-        return this.normalizeOpportunities(response.data)
+        if (!response.ok) {
+          const httpError = Object.assign(
+            new Error(`HTTP error fetching Merkl opportunities`),
+            { status: response.status },
+          )
+          throw httpError
+        }
+
+        const data = (await response.json()) as MerklOpportunitiesResponse
+        return this.normalizeOpportunities(data)
       } catch (error) {
         lastError = error
 

--- a/src/app/services/externalApis/yearnApi.ts
+++ b/src/app/services/externalApis/yearnApi.ts
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import { config } from '../../config'
 import type { YearnVault } from '../../types'
 import { logVaultAprDebug } from '../aprCalcs/debugLogger'
@@ -26,8 +25,13 @@ export class YearnApiService {
 
       const url: string = `${this.apiUrl}/vaults/katana?${params}`
 
-      const response = await axios.get<YearnVault[]>(url)
-      const vaults: YearnVault[] = response.data || []
+      const response = await fetch(url)
+
+      if (!response.ok) {
+        throw new Error(`HTTP error fetching vaults from yDaemon: ${response.status}`)
+      }
+
+      const vaults: YearnVault[] = (await response.json() as YearnVault[]) || []
 
       for (const vault of vaults) {
         logVaultAprDebug({


### PR DESCRIPTION
Replaces Axios with native fetch throughout the APR service.

To test: bun run dev and confirm rates match live service.