### PR TITLE
fix: restore missing KAT rewards for vbWBTC strategies

### DIFF
--- a/src/app/services/aprCalcs/morphoAprCalculator.test.ts
+++ b/src/app/services/aprCalcs/morphoAprCalculator.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { YearnVault } from '../../types'
+
+const mocks = vi.hoisted(() => ({
+  getMorphoOpportunities: vi.fn(),
+  getActiveMorphoStrategies: vi.fn(),
+  getMorphoVaultsFromStrategies: vi.fn(),
+}))
+
+vi.mock('../externalApis/merklApi', () => ({
+  MerklApiService: vi.fn().mockImplementation(() => ({
+    getMorphoOpportunities: mocks.getMorphoOpportunities,
+  })),
+}))
+
+vi.mock('../externalApis/yearnApi', () => ({
+  YearnApiService: vi.fn().mockImplementation(() => ({
+    getActiveMorphoStrategies: mocks.getActiveMorphoStrategies,
+  })),
+}))
+
+vi.mock('../contractReader', () => ({
+  ContractReaderService: vi.fn().mockImplementation(() => ({
+    getMorphoVaultsFromStrategies: mocks.getMorphoVaultsFromStrategies,
+  })),
+}))
+
+import { MorphoAprCalculator } from './morphoAprCalculator'
+
+const VAULT_ADDRESS = '0x00000000000000000000000000000000000000aa'
+const STRATEGY_ADDRESS = '0x00000000000000000000000000000000000000bb'
+const MORPHO_VAULT_ADDRESS = '0x00000000000000000000000000000000000000cc'
+const CANONICAL_KAT_ADDRESS = '0x7F1f4b4b29f5058fA32CC7a97141b8D7e5ABDC2d'
+const WRAPPED_KAT_ADDRESS = '0x3ba1fbC4c3aEA775d335b31fb53778f46FD3a330'
+
+const vault: YearnVault = {
+  address: VAULT_ADDRESS,
+  symbol: 'yvvbWBTC',
+  name: 'WBTC yVault',
+  chainID: 747474,
+  token: {
+    address: '0x00000000000000000000000000000000000000dd',
+    name: 'Vault Bridge WBTC',
+    symbol: 'vbWBTC',
+    description: '',
+    decimals: 8,
+  },
+  tvl: {
+    totalAssets: '100',
+    tvl: 100,
+    price: 1,
+  },
+  strategies: [
+    {
+      address: STRATEGY_ADDRESS,
+      name: 'Morpho vbWBTC/yvUSDC Lender Borrower',
+      status: 'active',
+      details: {
+        totalDebt: '100',
+        totalLoss: '0',
+        totalGain: '0',
+        performanceFee: 0,
+        lastReport: 0,
+        debtRatio: 10_000,
+      },
+    },
+  ],
+  apr: {
+    netAPR: 0,
+  },
+}
+
+describe('MorphoAprCalculator', () => {
+  beforeEach(() => {
+    mocks.getMorphoOpportunities.mockReset()
+    mocks.getActiveMorphoStrategies.mockReset()
+    mocks.getMorphoVaultsFromStrategies.mockReset()
+  })
+
+  it('includes canonical and wrapped KAT campaign aliases for lender-borrower strategies', async () => {
+    mocks.getActiveMorphoStrategies.mockReturnValue([STRATEGY_ADDRESS])
+    mocks.getMorphoVaultsFromStrategies.mockResolvedValue({
+      [STRATEGY_ADDRESS]: MORPHO_VAULT_ADDRESS,
+    })
+    mocks.getMorphoOpportunities.mockResolvedValue([
+      {
+        identifier: STRATEGY_ADDRESS,
+        name: 'Deposit vbWBTC in Morpho vbWBTC/yvUSDC Lender Borrower',
+        campaigns: [
+          {
+            campaignId: 'campaign-canonical',
+            rewardToken: {
+              address: CANONICAL_KAT_ADDRESS,
+              symbol: 'KAT',
+              decimals: 18,
+            },
+          },
+          {
+            campaignId: 'campaign-wrapped',
+            rewardToken: {
+              address: WRAPPED_KAT_ADDRESS,
+              symbol: 'KAT',
+              decimals: 18,
+            },
+          },
+        ],
+        aprRecord: {
+          breakdowns: [
+            { identifier: 'campaign-canonical', value: 1.25 },
+            { identifier: 'campaign-wrapped', value: 0.75 },
+          ],
+        },
+      },
+    ])
+
+    const calculator = new MorphoAprCalculator()
+    const results = await calculator.calculateVaultAPRs([vault])
+
+    expect(results[VAULT_ADDRESS]).toEqual([
+      {
+        strategyAddress: STRATEGY_ADDRESS,
+        poolAddress: MORPHO_VAULT_ADDRESS,
+        poolType: 'morpho',
+        breakdown: {
+          apr: 1.25,
+          token: {
+            address: CANONICAL_KAT_ADDRESS,
+            symbol: 'KAT',
+            decimals: 18,
+          },
+          weight: 0,
+        },
+      },
+      {
+        strategyAddress: STRATEGY_ADDRESS,
+        poolAddress: MORPHO_VAULT_ADDRESS,
+        poolType: 'morpho',
+        breakdown: {
+          apr: 0.75,
+          token: {
+            address: WRAPPED_KAT_ADDRESS,
+            symbol: 'KAT',
+            decimals: 18,
+          },
+          weight: 0,
+        },
+      },
+    ])
+  })
+})

--- a/src/app/services/aprCalcs/morphoAprCalculator.ts
+++ b/src/app/services/aprCalcs/morphoAprCalculator.ts
@@ -4,6 +4,7 @@ import { MerklApiService } from '../externalApis/merklApi'
 import { YearnApiService } from '../externalApis/yearnApi'
 import { ContractReaderService } from '../contractReader'
 import type { APRCalculator, RewardCalculatorResult } from './types'
+import { KATANA_REWARD_TOKEN_ADDRESSES } from '../katanaRewardTokens'
 import { calculateStrategyAPR } from './utils'
 
 export class MorphoAprCalculator implements APRCalculator {
@@ -21,8 +22,6 @@ export class MorphoAprCalculator implements APRCalculator {
     vaults: YearnVault[]
   ): Promise<Record<string, RewardCalculatorResult[]>> {
     const morphoOpportunities = await this.merklApi.getMorphoOpportunities()
-    const MORPHO_WRAPPED_KAT_ADDRESS =
-      '0x3ba1fbC4c3aEA775d335b31fb53778f46FD3a330'
 
     const vaultStrategyPairs = _.chain(vaults)
       .map((vault) => ({
@@ -63,7 +62,7 @@ export class MorphoAprCalculator implements APRCalculator {
               poolAddress,
               morphoOpportunities,
               'morpho',
-              MORPHO_WRAPPED_KAT_ADDRESS
+              [...KATANA_REWARD_TOKEN_ADDRESSES]
             )
 
             return result || []

--- a/src/app/services/aprCalcs/sushiAprCalculator.test.ts
+++ b/src/app/services/aprCalcs/sushiAprCalculator.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { YearnVault } from '../../types'
+
+const mocks = vi.hoisted(() => ({
+  getSushiOpportunities: vi.fn(),
+  getErc20LogProcessorOpportunities: vi.fn(),
+  getActiveSushiStrategies: vi.fn(),
+  getSushiPoolsFromStrategies: vi.fn(),
+}))
+
+vi.mock('../externalApis/merklApi', () => ({
+  MerklApiService: vi.fn().mockImplementation(() => ({
+    getSushiOpportunities: mocks.getSushiOpportunities,
+    getErc20LogProcessorOpportunities: mocks.getErc20LogProcessorOpportunities,
+  })),
+}))
+
+vi.mock('../externalApis/yearnApi', () => ({
+  YearnApiService: vi.fn().mockImplementation(() => ({
+    getActiveSushiStrategies: mocks.getActiveSushiStrategies,
+  })),
+}))
+
+vi.mock('../contractReader', () => ({
+  ContractReaderService: vi.fn().mockImplementation(() => ({
+    getSushiPoolsFromStrategies: mocks.getSushiPoolsFromStrategies,
+  })),
+}))
+
+import { SushiAprCalculator } from './sushiAprCalculator'
+
+const VAULT_ADDRESS = '0x00000000000000000000000000000000000000aa'
+const STRATEGY_ADDRESS = '0x00000000000000000000000000000000000000bb'
+const POOL_ADDRESS = '0x00000000000000000000000000000000000000cc'
+const CANONICAL_KAT_ADDRESS = '0x7F1f4b4b29f5058fA32CC7a97141b8D7e5ABDC2d'
+
+const vault: YearnVault = {
+  address: VAULT_ADDRESS,
+  symbol: 'yvvbWBTC',
+  name: 'WBTC yVault',
+  chainID: 747474,
+  token: {
+    address: '0x00000000000000000000000000000000000000dd',
+    name: 'Vault Bridge WBTC',
+    symbol: 'vbWBTC',
+    description: '',
+    decimals: 8,
+  },
+  tvl: {
+    totalAssets: '100',
+    tvl: 100,
+    price: 1,
+  },
+  strategies: [
+    {
+      address: STRATEGY_ADDRESS,
+      name: 'Single Sided Steer vbWBTC-BTCK vbWBTC',
+      status: 'active',
+      details: {
+        totalDebt: '100',
+        totalLoss: '0',
+        totalGain: '0',
+        performanceFee: 0,
+        lastReport: 0,
+        debtRatio: 10_000,
+      },
+    },
+  ],
+  apr: {
+    netAPR: 0,
+  },
+}
+
+describe('SushiAprCalculator', () => {
+  beforeEach(() => {
+    mocks.getSushiOpportunities.mockReset()
+    mocks.getErc20LogProcessorOpportunities.mockReset()
+    mocks.getActiveSushiStrategies.mockReset()
+    mocks.getSushiPoolsFromStrategies.mockReset()
+  })
+
+  it('falls back to direct ERC20 log processor opportunities for single-sided steer strategies', async () => {
+    mocks.getActiveSushiStrategies.mockReturnValue([STRATEGY_ADDRESS])
+    mocks.getSushiPoolsFromStrategies.mockResolvedValue({
+      [STRATEGY_ADDRESS.toLowerCase()]: POOL_ADDRESS,
+    })
+    mocks.getSushiOpportunities.mockResolvedValue([
+      {
+        identifier: POOL_ADDRESS,
+        name: 'Provide liquidity to Sushi pool',
+        campaigns: [
+          {
+            campaignId: 'pool-campaign',
+            rewardToken: {
+              address: CANONICAL_KAT_ADDRESS,
+              symbol: 'KAT',
+              decimals: 18,
+            },
+          },
+        ],
+        aprRecord: {
+          breakdowns: [{ identifier: 'pool-campaign', value: 0.4 }],
+        },
+      },
+    ])
+    mocks.getErc20LogProcessorOpportunities.mockResolvedValue([
+      {
+        identifier: STRATEGY_ADDRESS,
+        name: 'Deposit vbWBTC in Single Sided Steer vbWBTC-BTCK vbWBTC',
+        campaigns: [
+          {
+            campaignId: 'strategy-campaign',
+            rewardToken: {
+              address: CANONICAL_KAT_ADDRESS,
+              symbol: 'KAT',
+              decimals: 18,
+            },
+          },
+        ],
+        aprRecord: {
+          breakdowns: [{ identifier: 'strategy-campaign', value: 1.5 }],
+        },
+      },
+    ])
+
+    const calculator = new SushiAprCalculator()
+    const results = await calculator.calculateVaultAPRs([vault])
+
+    expect(results[VAULT_ADDRESS]).toEqual([
+      {
+        strategyAddress: STRATEGY_ADDRESS,
+        poolAddress: POOL_ADDRESS,
+        poolType: 'sushi',
+        breakdown: {
+          apr: 1.5,
+          token: {
+            address: CANONICAL_KAT_ADDRESS,
+            symbol: 'KAT',
+            decimals: 18,
+          },
+          weight: 0,
+        },
+      },
+    ])
+  })
+})

--- a/src/app/services/aprCalcs/sushiAprCalculator.ts
+++ b/src/app/services/aprCalcs/sushiAprCalculator.ts
@@ -4,6 +4,7 @@ import { MerklApiService } from '../externalApis/merklApi'
 import { YearnApiService } from '../externalApis/yearnApi'
 import { ContractReaderService } from '../contractReader'
 import type { APRCalculator, RewardCalculatorResult } from './types'
+import { KATANA_REWARD_TOKEN_ADDRESSES } from '../katanaRewardTokens'
 import { calculateStrategyAPR } from './utils'
 
 export class SushiAprCalculator implements APRCalculator {
@@ -20,9 +21,15 @@ export class SushiAprCalculator implements APRCalculator {
   async calculateVaultAPRs(
     vaults: YearnVault[]
   ): Promise<Record<string, RewardCalculatorResult[]>> {
-    const sushiOpportunities = await this.merklApi.getSushiOpportunities()
-    const SUSHI_WRAPPED_KAT_ADDRESS =
-      '0x6E9C1F88a960fE63387eb4b71BC525a9313d8461'
+    const [sushiPoolOpportunities, directStrategyOpportunities] =
+      await Promise.all([
+        this.merklApi.getSushiOpportunities(),
+        this.merklApi.getErc20LogProcessorOpportunities(),
+      ])
+    const sushiOpportunities = [
+      ...directStrategyOpportunities,
+      ...sushiPoolOpportunities,
+    ]
 
     const vaultStrategyPairs = _.chain(vaults)
       .map((vault) => ({
@@ -67,7 +74,7 @@ export class SushiAprCalculator implements APRCalculator {
               poolAddress,
               sushiOpportunities,
               'sushi',
-              SUSHI_WRAPPED_KAT_ADDRESS
+              [...KATANA_REWARD_TOKEN_ADDRESSES]
             )
 
             return result || []

--- a/src/app/services/aprCalcs/utils.ts
+++ b/src/app/services/aprCalcs/utils.ts
@@ -145,13 +145,16 @@ export const calculateStrategyAPR = (
   poolAddress: string,
   opportunities: Opportunity[],
   poolType: string,
-  targetRewardTokenAddress: string
+  targetRewardTokenAddress: string | string[]
 ): RewardCalculatorResult[] | null => {
   const opportunity = findBestStrategyOpportunity(
     opportunities,
     strategyAddress,
     poolAddress
   )
+  const targetRewardTokenAddresses = Array.isArray(targetRewardTokenAddress)
+    ? targetRewardTokenAddress
+    : [targetRewardTokenAddress]
 
   if (!opportunity?.campaigns?.length) {
     console.log(
@@ -165,9 +168,8 @@ export const calculateStrategyAPR = (
   // Find all campaigns with the specified rewardToken address
 
   const targetCampaigns = opportunity.campaigns.filter((campaign: Campaign) => {
-    return safeIsAddressEqual(
-      campaign.rewardToken.address,
-      targetRewardTokenAddress
+    return targetRewardTokenAddresses.some((address) =>
+      safeIsAddressEqual(campaign.rewardToken.address, address)
     )
   })
 

--- a/src/app/services/externalApis/merklApi.test.ts
+++ b/src/app/services/externalApis/merklApi.test.ts
@@ -64,11 +64,11 @@ describe('MerklApiService', () => {
     expect(mocks.fetchGet).toHaveBeenCalledTimes(2)
     expect(mocks.fetchGet).toHaveBeenNthCalledWith(
       1,
-      expect.stringContaining(`${config.merklApiUrl}/v4/opportunities`),
+      expect.stringMatching(new RegExp(`${config.merklApiUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/v4/opportunities.*items=100.*page=0`)),
     )
     expect(mocks.fetchGet).toHaveBeenNthCalledWith(
       2,
-      expect.stringContaining('https://api.merkl.fr/v4/opportunities'),
+      expect.stringMatching(/https:\/\/api\.merkl\.fr\/v4\/opportunities.*items=100.*page=0/),
     )
     expect(consoleWarn).toHaveBeenCalledWith(
       expect.stringContaining(
@@ -96,7 +96,7 @@ describe('MerklApiService', () => {
     expect(opportunities).toEqual([])
     expect(mocks.fetchGet).toHaveBeenCalledTimes(1)
     expect(mocks.fetchGet).toHaveBeenCalledWith(
-      expect.stringContaining(`${customApiUrl}/v4/opportunities`),
+      expect.stringMatching(/https:\/\/merkl-proxy\.internal\/v4\/opportunities.*items=100.*page=0/),
     )
     expect(consoleWarn).not.toHaveBeenCalled()
     expect(consoleError).toHaveBeenCalledWith(
@@ -119,6 +119,49 @@ describe('MerklApiService', () => {
     )
     expect(mocks.fetchGet).toHaveBeenCalledWith(
       expect.stringMatching(/\/v4\/opportunities\?.*campaigns=true/),
+    )
+    expect(mocks.fetchGet).toHaveBeenCalledWith(
+      expect.stringMatching(/\/v4\/opportunities\?.*items=100/),
+    )
+    expect(mocks.fetchGet).toHaveBeenCalledWith(
+      expect.stringMatching(/\/v4\/opportunities\?.*page=0/),
+    )
+  })
+
+  it('fetches additional Merkl pages when the current page is full', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({
+      chainId: 747474,
+      name: `Opportunity ${index}`,
+      tvl: index,
+      status: 'LIVE',
+      identifier: `0x${String(index).padStart(40, '0')}`,
+      campaigns: [],
+    }))
+    const secondPageOpportunity = {
+      chainId: 747474,
+      name: 'Opportunity 101',
+      tvl: 101,
+      status: 'LIVE',
+      identifier: '0x0000000000000000000000000000000000000101',
+      campaigns: [],
+    }
+
+    mocks.fetchGet
+      .mockImplementationOnce(() => makeOkResponse(firstPage))
+      .mockImplementationOnce(() => makeOkResponse([secondPageOpportunity]))
+
+    const service = new MerklApiService()
+    const opportunities = await service.getErc20LogProcessorOpportunities()
+
+    expect(opportunities).toHaveLength(101)
+    expect(opportunities[100]).toEqual(secondPageOpportunity)
+    expect(mocks.fetchGet).toHaveBeenNthCalledWith(
+      1,
+      expect.stringMatching(/\/v4\/opportunities\?.*items=100.*page=0/),
+    )
+    expect(mocks.fetchGet).toHaveBeenNthCalledWith(
+      2,
+      expect.stringMatching(/\/v4\/opportunities\?.*items=100.*page=1/),
     )
   })
 
@@ -219,15 +262,15 @@ describe('MerklApiService', () => {
     expect(mocks.fetchGet).toHaveBeenCalledTimes(3)
     expect(mocks.fetchGet).toHaveBeenNthCalledWith(
       1,
-      expect.stringContaining(`${config.merklApiUrl}/v4/opportunities`),
+      expect.stringMatching(new RegExp(`${config.merklApiUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/v4/opportunities.*items=100.*page=0`)),
     )
     expect(mocks.fetchGet).toHaveBeenNthCalledWith(
       2,
-      expect.stringContaining('https://api.merkl.fr/v4/opportunities'),
+      expect.stringMatching(/https:\/\/api\.merkl\.fr\/v4\/opportunities.*items=100.*page=0/),
     )
     expect(mocks.fetchGet).toHaveBeenNthCalledWith(
       3,
-      expect.stringContaining('https://api-merkl.angle.money/v4/opportunities'),
+      expect.stringMatching(/https:\/\/api-merkl\.angle\.money\/v4\/opportunities.*items=100.*page=0/),
     )
     expect(consoleWarn).toHaveBeenCalledTimes(2)
     expect(consoleError).toHaveBeenCalledWith(

--- a/src/app/services/externalApis/merklApi.ts
+++ b/src/app/services/externalApis/merklApi.ts
@@ -25,6 +25,8 @@ const extractAddressFromIdentifier = (
   return isAddress(candidate) ? candidate : undefined
 }
 
+const MERKL_PAGE_SIZE = 100
+
 const normalizeApiUrl = (apiUrl: string): string => apiUrl.replace(/\/+$/, '')
 
 export class MerklApiService {
@@ -135,23 +137,36 @@ export class MerklApiService {
       const apiUrl = this.apiUrls[index]
 
       try {
-        const searchParams = new URLSearchParams(
-          Object.entries(params).map(([k, v]) => [k, String(v)]),
-        )
-        const response = await fetch(
-          `${apiUrl}/v4/opportunities?${searchParams}`,
-        )
+        const aggregatedOpportunities: MerklOpportunity[] = []
 
-        if (!response.ok) {
-          const httpError = Object.assign(
-            new Error(`HTTP error fetching Merkl opportunities`),
-            { status: response.status },
+        for (let page = 0; ; page += 1) {
+          const searchParams = new URLSearchParams(
+            Object.entries({
+              ...params,
+              items: MERKL_PAGE_SIZE,
+              page,
+            }).map(([k, v]) => [k, String(v)]),
           )
-          throw httpError
-        }
+          const response = await fetch(
+            `${apiUrl}/v4/opportunities?${searchParams}`,
+          )
 
-        const data = (await response.json()) as MerklOpportunitiesResponse
-        return this.normalizeOpportunities(data)
+          if (!response.ok) {
+            const httpError = Object.assign(
+              new Error(`HTTP error fetching Merkl opportunities`),
+              { status: response.status },
+            )
+            throw httpError
+          }
+
+          const data = (await response.json()) as MerklOpportunitiesResponse
+          const pageOpportunities = this.normalizeOpportunities(data)
+          aggregatedOpportunities.push(...pageOpportunities)
+
+          if (pageOpportunities.length < MERKL_PAGE_SIZE) {
+            return aggregatedOpportunities
+          }
+        }
       } catch (error) {
         lastError = error
 


### PR DESCRIPTION
## Summary
- restore missing KAT rewards for vbWBTC lender/borrower and steer strategies
- paginate Merkl opportunity fetches so later-page live opportunities are included
- allow strategy APR matching across the full KAT token alias list and direct single-sided steer opportunities
- add regression coverage for pagination, Morpho KAT aliases, and direct Steer strategy matching

## Test Plan
- bunx vitest run -c vitest.config.ts src/app/services/externalApis/merklApi.test.ts src/app/services/aprCalcs/morphoAprCalculator.test.ts src/app/services/aprCalcs/sushiAprCalculator.test.ts src/app/services/aprCalcs/utils.test.ts
