### PR TITLE
Remove fixed kat rewards

### DIFF
--- a/docs/api-integration-guide.md
+++ b/docs/api-integration-guide.md
@@ -190,7 +190,7 @@ APR units:
 - `strategies[].rewardToken` and `strategies[].underlyingContract` when the strategy pool/token could be resolved
 - `apr.extra.katanaRewardsAPR` (legacy alias)
 - `apr.extra.katanaAppRewardsAPR` from Yearn vault-level rewards
-- `apr.extra.fixedRateKatanaRewards` (legacy fixed-rate schedule scaled by `live KAT price / assumed $0.10 KAT price`)
+- `apr.extra.fixedRateKatanaRewards` (legacy compatibility field; fixed-rate KAT rewards have ended and this is always `0`)
 - `apr.extra.katanaBonusAPY` (`0` post-TGE, kept for compatibility)
 - `apr.extra.katanaNativeYield` (`vault.apr.netAPR`)
 - `apr.extra.steerPointsPerDollar` (from strategy debt-weighted rates)
@@ -342,9 +342,8 @@ From `DataCacheService.generateVaultAPRData()`:
 Notes:
 
 - `katanaAppRewardsAPR` continues to come from Yearn vault-level Merkl APR breakdowns.
-- `fixedRateKatanaRewards` uses the legacy fixed-rate table as the APR basis at an assumed `KAT = $0.10 USD`, then scales by `livePrice / 0.10`.
+- `fixedRateKatanaRewards` is kept as a legacy compatibility field, but fixed-rate KAT rewards have ended and the service now returns `0`.
 - `katanaBonusAPY` remains `0`.
-- The example `fixedRateKatanaRewards` values below assume `KAT = $0.10 USD`, which matches the historical fixed-rate program basis.
 
 ```json
 [
@@ -353,7 +352,7 @@ Notes:
     "symbol": "yvvbUSDC",
     "name": "USDC yVault",
     "katanaAppRewardsAPR": 0.005709245156139802,
-    "fixedRateKatanaRewards": 0.35,
+    "fixedRateKatanaRewards": 0,
     "katanaBonusAPY": 0,
     "katanaNativeYield": 0.03392437419763983,
     "steerPointsPerDollar": 0.1711
@@ -363,7 +362,7 @@ Notes:
     "symbol": "AUSD",
     "name": "AUSD yVault",
     "katanaAppRewardsAPR": 0,
-    "fixedRateKatanaRewards": 0.35,
+    "fixedRateKatanaRewards": 0,
     "katanaBonusAPY": 0,
     "katanaNativeYield": 0.11184248250750017,
     "steerPointsPerDollar": 0.1294
@@ -373,7 +372,7 @@ Notes:
     "symbol": "yvvbWBTC",
     "name": "WBTC yVault",
     "katanaAppRewardsAPR": 0,
-    "fixedRateKatanaRewards": 0.07,
+    "fixedRateKatanaRewards": 0,
     "katanaBonusAPY": 0,
     "katanaNativeYield": 0.0006326777539145123,
     "steerPointsPerDollar": 0

--- a/src/app/quick-apys/page.tsx
+++ b/src/app/quick-apys/page.tsx
@@ -18,7 +18,6 @@ type VaultDisplay = {
   name: string
   monthlyNetAPY: string
   katanaAppRewardsAPR: string
-  fixedRateKatanaRewards: string
   totalAPR: string
   strategies: StrategyDisplay[]
 }
@@ -75,17 +74,13 @@ export default function QuickAPYs(): React.ReactElement {
         const displayVaults: VaultDisplay[] = vaultsArr.map((vault) => {
           const monthlyNetAPY = vault.apr?.netAPR || 0
           const katanaAppRewardsAPR = vault.apr?.extra?.katanaAppRewardsAPR || 0
-          const fixedRateKatanaRewards =
-            vault.apr?.extra?.fixedRateKatanaRewards || 0
-          const totalAPR =
-            monthlyNetAPY + katanaAppRewardsAPR + fixedRateKatanaRewards
+          const totalAPR = monthlyNetAPY + katanaAppRewardsAPR
 
           return {
             key: vault.address,
             name: vault.name,
             monthlyNetAPY: formatPercent(monthlyNetAPY),
             katanaAppRewardsAPR: formatPercent(katanaAppRewardsAPR),
-            fixedRateKatanaRewards: formatPercent(fixedRateKatanaRewards),
             totalAPR: formatPercent(totalAPR),
             strategies: (vault.strategies || []).map((strategy) => ({
               key: strategy.address,
@@ -135,13 +130,12 @@ export default function QuickAPYs(): React.ReactElement {
         ) : (
           <>
             <div className="w-full overflow-x-auto">
-              <table className="min-w-[980px] w-full table-fixed border-collapse text-left">
+              <table className="min-w-[860px] w-full table-fixed border-collapse text-left">
                 <colgroup>
-                  <col className="w-[40%]" />
-                  <col className="w-[15%]" />
-                  <col className="w-[15%]" />
-                  <col className="w-[15%]" />
-                  <col className="w-[15%]" />
+                  <col className="w-[46%]" />
+                  <col className="w-[18%]" />
+                  <col className="w-[18%]" />
+                  <col className="w-[18%]" />
                 </colgroup>
                 <thead>
                   <tr>
@@ -153,9 +147,6 @@ export default function QuickAPYs(): React.ReactElement {
                     </th>
                     <th className="whitespace-nowrap px-1 py-2 text-right text-sm text-zinc-500 dark:text-zinc-400">
                       KAT Strategy APR (%)
-                    </th>
-                    <th className="whitespace-nowrap px-1 py-2 text-right text-sm text-zinc-500 dark:text-zinc-400">
-                      KAT Vault Bonus APR (%)
                     </th>
                     <th className="whitespace-nowrap px-1 py-2 text-right text-sm font-bold text-zinc-500 dark:text-zinc-400">
                       Total APR (%)
@@ -195,9 +186,6 @@ export default function QuickAPYs(): React.ReactElement {
                           <td className="px-1 py-3 text-right text-sm tabular-nums">
                             {vault.katanaAppRewardsAPR}%
                           </td>
-                          <td className="px-1 py-3 text-right text-sm tabular-nums">
-                            {vault.fixedRateKatanaRewards}%
-                          </td>
                           <td className="px-1 py-3 text-right text-sm font-bold tabular-nums">
                             {vault.totalAPR}%
                           </td>
@@ -233,9 +221,6 @@ export default function QuickAPYs(): React.ReactElement {
                                 <td className="px-1 py-2 text-right text-sm text-zinc-400 dark:text-zinc-600">
                                   -
                                 </td>
-                                <td className="px-1 py-2 text-right text-sm text-zinc-400 dark:text-zinc-600">
-                                  -
-                                </td>
                               </tr>
                             ))
                           ) : (
@@ -243,7 +228,6 @@ export default function QuickAPYs(): React.ReactElement {
                               <td className="px-2 py-2 pl-11 text-sm text-zinc-500 dark:text-zinc-400">
                                 No strategies available for this vault.
                               </td>
-                              <td className="px-2 py-2" />
                               <td className="px-2 py-2" />
                               <td className="px-2 py-2" />
                               <td className="px-2 py-2" />

--- a/src/app/services/dataCache.test.ts
+++ b/src/app/services/dataCache.test.ts
@@ -3,7 +3,6 @@ import type { YearnVault } from '../types'
 
 const mocks = vi.hoisted(() => ({
   mockGetVaults: vi.fn(),
-  mockGetTokenPriceUsd: vi.fn(),
   mockCalculateYearnVaultAPRs: vi.fn(),
   mockCalculateMorphoVaultAPRs: vi.fn(),
   mockCalculateSushiVaultAPRs: vi.fn(),
@@ -14,12 +13,6 @@ const mocks = vi.hoisted(() => ({
 vi.mock('./externalApis/yearnApi', () => ({
   YearnApiService: vi.fn().mockImplementation(() => ({
     getVaults: mocks.mockGetVaults,
-  })),
-}))
-
-vi.mock('./externalApis/katanaPriceService', () => ({
-  KatanaPriceService: vi.fn().mockImplementation(() => ({
-    getTokenPriceUsd: mocks.mockGetTokenPriceUsd,
   })),
 }))
 
@@ -70,13 +63,11 @@ const makeVault = (overrides: Partial<YearnVault> = {}): YearnVault => ({
 describe('DataCacheService.generateVaultAPRData', () => {
   beforeEach(() => {
     mocks.mockGetVaults.mockReset()
-    mocks.mockGetTokenPriceUsd.mockReset()
     mocks.mockCalculateYearnVaultAPRs.mockReset()
     mocks.mockCalculateMorphoVaultAPRs.mockReset()
     mocks.mockCalculateSushiVaultAPRs.mockReset()
     mocks.mockCalculateSteerPoints.mockReset()
     mocks.logVaultAprDebug.mockReset()
-    mocks.mockGetTokenPriceUsd.mockResolvedValue(1)
     mocks.mockCalculateYearnVaultAPRs.mockResolvedValue({})
     mocks.mockCalculateMorphoVaultAPRs.mockResolvedValue({})
     mocks.mockCalculateSushiVaultAPRs.mockResolvedValue({})
@@ -232,12 +223,11 @@ describe('DataCacheService.generateVaultAPRData', () => {
     )
   })
 
-  it('scales fixed rate rewards by the live-to-assumed KAT price ratio', async () => {
+  it('does not apply ended fixed-rate KAT rewards', async () => {
     const vault = makeVault({
       symbol: 'yvvbUSDC',
     })
     mocks.mockGetVaults.mockResolvedValue([vault])
-    mocks.mockGetTokenPriceUsd.mockResolvedValue(0.5)
     mocks.mockCalculateYearnVaultAPRs.mockResolvedValue({
       [vault.address]: [
         {
@@ -260,7 +250,7 @@ describe('DataCacheService.generateVaultAPRData', () => {
     const service = new DataCacheService()
     const data = await service.generateVaultAPRData()
 
-    expect(data[vault.address].apr?.extra?.fixedRateKatanaRewards).toBe(1.75)
+    expect(data[vault.address].apr?.extra?.fixedRateKatanaRewards).toBe(0)
   })
 
   it('keeps zero-result strategy entries when a strategy mapping or opportunity is missing', async () => {

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -2,13 +2,11 @@ import _ from 'lodash'
 import { config } from '../config/index'
 import type { YearnVault } from '../types/index'
 import { YearnApiService } from './externalApis/yearnApi'
-import { KatanaPriceService } from './externalApis/katanaPriceService'
 import { MorphoAprCalculator } from './aprCalcs/morphoAprCalculator'
 import { SushiAprCalculator } from './aprCalcs/sushiAprCalculator'
 import { YearnAprCalculator } from './aprCalcs/yearnAprCalculator'
 import { SteerPointsCalculator } from './pointsCalcs/steerPointsCalculator'
 import { logVaultAprDebug } from './aprCalcs/debugLogger'
-import { CANONICAL_KAT_ADDRESS } from './katanaRewardTokens'
 import {
   type RewardCalculatorResult,
   TokenBreakdown,
@@ -35,30 +33,8 @@ interface StrategyRewardSummary {
   underlyingContract?: string
 }
 
-const ASSUMED_KAT_PRICE_USD = 0.1
-
-const FIXED_RATE_APR_AT_ASSUMED_KAT_PRICE: Record<
-  | 'yvvbETH'
-  | 'yvvbUSDC'
-  | 'yvvbUSDT'
-  | 'AUSD'
-  | 'yvvbWBTC'
-  | 'yvvbUSDS'
-  | 'yvwstETH',
-  number
-> = {
-  yvvbETH: 0.14,
-  yvvbUSDC: 0.35,
-  yvvbUSDT: 0.35,
-  AUSD: 0.35,
-  yvvbWBTC: 0.07,
-  yvvbUSDS: 0.0,
-  yvwstETH: 0.0,
-}
-
 export class DataCacheService {
   private yearnApi: YearnApiService
-  private katanaPriceService: KatanaPriceService
   private yearnAprCalculator: YearnAprCalculator
   private morphoAprCalculator: MorphoAprCalculator
   private sushiAprCalculator: SushiAprCalculator
@@ -66,7 +42,6 @@ export class DataCacheService {
 
   constructor() {
     this.yearnApi = new YearnApiService()
-    this.katanaPriceService = new KatanaPriceService()
     this.yearnAprCalculator = new YearnAprCalculator()
     this.morphoAprCalculator = new MorphoAprCalculator()
     this.sushiAprCalculator = new SushiAprCalculator()
@@ -91,17 +66,10 @@ export class DataCacheService {
       yearnAPRs,
       morphoAPRs,
       sushiAPRs,
-      katanaTokenPriceUsd,
-      // fixedRateAPRs
     ] = await Promise.all([
       this.yearnAprCalculator.calculateVaultAPRs(vaults),
       this.morphoAprCalculator.calculateVaultAPRs(vaults),
       this.sushiAprCalculator.calculateVaultAPRs(vaults),
-      this.katanaPriceService.getTokenPriceUsd(
-        config.katanaChainId,
-        CANONICAL_KAT_ADDRESS,
-      ),
-      // this.yearnAprCalculator.calculateFixedRateVaultAPRs(vaults),
     ])
 
     // Aggregate results for each vault
@@ -112,7 +80,6 @@ export class DataCacheService {
             yearnAPRs[vault.address],
             morphoAPRs[vault.address],
             sushiAPRs[vault.address],
-            // fixedRateAPRs[vault.address],
           ])
             .flattenDeep()
             .compact()
@@ -148,7 +115,7 @@ export class DataCacheService {
 
           return [
             vault.address,
-            this.aggregateVaultResults(vault, allResults, katanaTokenPriceUsd),
+            this.aggregateVaultResults(vault, allResults),
           ]
         } catch (error) {
           console.error(`Error processing vault ${vault.address}:`, error)
@@ -191,7 +158,6 @@ export class DataCacheService {
   private aggregateVaultResults(
     vault: YearnVault,
     results: VaultRewardCalculatorResult[],
-    katanaTokenPriceUsd: number,
   ): YearnVault {
     const strategyResults = results.filter(
       (result): result is RewardCalculatorResult => 'strategyAddress' in result,
@@ -236,14 +202,6 @@ export class DataCacheService {
       0,
     )
 
-    const fixedRateBaseApr =
-      FIXED_RATE_APR_AT_ASSUMED_KAT_PRICE[
-        vault.symbol as keyof typeof FIXED_RATE_APR_AT_ASSUMED_KAT_PRICE
-      ] || 0
-
-    const fixedRateFromHardcoded =
-      fixedRateBaseApr * (katanaTokenPriceUsd / ASSUMED_KAT_PRICE_USD)
-
     const vaultKatanaBonusAPY = 0
 
     const katanaNativeYield = vault.apr?.netAPR || 0
@@ -254,7 +212,7 @@ export class DataCacheService {
         ...(vault.apr?.extra || {}),
         katanaRewardsAPR: yearnVaultRewards || 0, // legacy field
         katanaAppRewardsAPR: yearnVaultRewards || 0,
-        fixedRateKatanaRewards: fixedRateFromHardcoded || 0,
+        fixedRateKatanaRewards: 0,
         katanaBonusAPY: vaultKatanaBonusAPY,
         katanaNativeYield,
         steerPointsPerDollar:


### PR DESCRIPTION
The KAT rewards distributed by the Katana team have ended as of May 30th. This commit/PR sets them to 0 and removes now extraneous that is not needed anymore.

To test, visit the preview vercel site and confirm that `[address].apr.extra.fixedRateKatanaRewards` returns 0 for all vaults and the column no longer shows on the /quick-apys route.