### PR TITLE
Feat Replace yDaemon with Kong

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ KONG_WEBHOOK_SECRET=
 
 # Optional (defaults shown)
 # PORT=3000
+# KONG_BASE_URI=https://kong.yearn.fi/api/rest
 # YDAEMON_BASE_URI=https://ydaemon.yearn.fi
 # Default Merkl host; public fallbacks are only used while this stays on api.merkl.xyz
 # MERKL_BASE_URI=https://api.merkl.xyz

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a Next.js app that provides APR and points data for Yearn vaults on Kata
 
 ## Start Here
 
-For a full explanation of how this service queries yDaemon and Merkl, how values are filtered, and why vault rewards may resolve to zero, read:
+For a full explanation of how this service queries Kong and Merkl, how values are filtered, and why vault rewards may resolve to zero, read:
 
 - [`docs/api-integration-guide.md`](./docs/api-integration-guide.md)
 

--- a/docs/api-integration-guide.md
+++ b/docs/api-integration-guide.md
@@ -8,7 +8,7 @@ If you are debugging rewards, adding new vault types, or validating Merkl behavi
 
 At request time, the service:
 
-1. Fetches Katana vaults from yDaemon.
+1. Fetches Katana vaults from Kong.
 2. Fetches live `ERC20LOGPROCESSOR` opportunities from Merkl (with campaigns).
 3. Filters Merkl campaigns with a local blacklist.
 4. Matches each vault to a Merkl opportunity.
@@ -36,35 +36,33 @@ At request time, the service:
   - `src/app/services/aprCalcs/utils.ts`
 - Shared reward-token allowlist:
   - `src/app/services/katanaRewardTokens.ts`
-- Points logic:
+- Legacy points logic:
   - `src/app/services/pointsCalcs/steerPointsCalculator.ts`
 
 ## External APIs Queried
 
-### yDaemon (vault universe)
+### Kong (vault universe)
 
 Base URL (default):
 
-- `https://ydaemon.yearn.fi`
+- `https://kong.yearn.fi/api/rest`
 
-Endpoint used by this repo:
+Endpoints used by this repo:
 
-- `GET /vaults/katana`
+- `GET /list/vaults/747474?origin=yearn`
+- `GET /snapshot/747474/:address`
 
-Query params used:
+Filtering and mapping:
 
-- `hideAlways=true`
-- `orderBy=featuringScore`
-- `orderDirection=desc`
-- `strategiesDetails=withDetails`
-- `strategiesCondition=inQueue`
-- `chainIDs=747474`
-- `limit=2500`
+- Keeps list entries where `origin === "yearn"` and `inclusion.isKatana === true`.
+- Hydrates each kept vault through the snapshot endpoint.
+- Maps snapshot `composition[]` into the existing `strategies[]` shape used by APR and points calculators.
 
 Example:
 
 ```bash
-curl -sS 'https://ydaemon.yearn.fi/vaults/katana?hideAlways=true&orderBy=featuringScore&orderDirection=desc&strategiesDetails=withDetails&strategiesCondition=inQueue&chainIDs=747474&limit=2500'
+curl -sS 'https://kong.yearn.fi/api/rest/list/vaults/747474?origin=yearn'
+curl -sS 'https://kong.yearn.fi/api/rest/snapshot/747474/0x80c34BD3A3569E126e7055831036aa7b212cB159'
 ```
 
 ### Merkl (opportunities and campaigns)
@@ -134,7 +132,7 @@ Notes:
 
 ### 1) Vault fetch
 
-`YearnApiService.getVaults()` fetches the Katana vault list from yDaemon.
+`YearnApiService.getVaults()` fetches the Katana vault list from Kong and hydrates each vault through Kong snapshots.
 
 ### 2) Merkl fetch
 
@@ -193,7 +191,7 @@ APR units:
 - `apr.extra.fixedRateKatanaRewards` (legacy compatibility field; fixed-rate KAT rewards have ended and this is always `0`)
 - `apr.extra.katanaBonusAPY` (`0` post-TGE, kept for compatibility)
 - `apr.extra.katanaNativeYield` (`vault.apr.netAPR`)
-- `apr.extra.steerPointsPerDollar` (from strategy debt-weighted rates)
+- `apr.extra.steerPointsPerDollar` (`0`; legacy field kept after the points program ended)
 
 Weighting notes:
 
@@ -232,12 +230,12 @@ Related doc:
 
 These were sampled from live upstream APIs on **March 9, 2026 (America/New_York)** and can change over time.
 
-### 1) yDaemon vault sample (USDC yVault)
+### 1) Kong vault snapshot sample (USDC yVault)
 
 Query:
 
 ```bash
-curl -sS 'https://ydaemon.yearn.fi/vaults/katana?hideAlways=true&orderBy=featuringScore&orderDirection=desc&strategiesDetails=withDetails&strategiesCondition=inQueue&chainIDs=747474&limit=2500'
+curl -sS 'https://kong.yearn.fi/api/rest/snapshot/747474/0x80c34BD3A3569E126e7055831036aa7b212cB159'
 ```
 
 Snippet:
@@ -344,6 +342,7 @@ Notes:
 - `katanaAppRewardsAPR` continues to come from Yearn vault-level Merkl APR breakdowns.
 - `fixedRateKatanaRewards` is kept as a legacy compatibility field, but fixed-rate KAT rewards have ended and the service now returns `0`.
 - `katanaBonusAPY` remains `0`.
+- `steerPointsPerDollar` is kept as a legacy compatibility field, but the Steer points program has ended and the service now returns `0`.
 
 ```json
 [
@@ -355,7 +354,7 @@ Notes:
     "fixedRateKatanaRewards": 0,
     "katanaBonusAPY": 0,
     "katanaNativeYield": 0.03392437419763983,
-    "steerPointsPerDollar": 0.1711
+    "steerPointsPerDollar": 0
   },
   {
     "address": "0x93Fec6639717b6215A48E5a72a162C50DCC40d68",
@@ -365,7 +364,7 @@ Notes:
     "fixedRateKatanaRewards": 0,
     "katanaBonusAPY": 0,
     "katanaNativeYield": 0.11184248250750017,
-    "steerPointsPerDollar": 0.1294
+    "steerPointsPerDollar": 0
   },
   {
     "address": "0xAa0362eCC584B985056E47812931270b99C91f9d",
@@ -399,7 +398,7 @@ Notes:
   - `fixedRateKatanaRewards`
   - `katanaBonusAPY`
   - `katanaNativeYield`
-  - `steerPointsPerDollar`
+  - `steerPointsPerDollar` (legacy, always `0`)
 - Also emits strategy-addressed `katRewardsAPR` rows for strategies where `strategyRewardsAPR` is present, reusing the incoming estimated-APR label so Kong can hydrate them onto vault composition entries.
 
 ### `GET /api/health`
@@ -414,7 +413,7 @@ Notes:
 
 When a vault looks wrong:
 
-1. Confirm vault exists in yDaemon query output.
+1. Confirm vault exists in Kong list output and its snapshot endpoint returns strategy composition.
 2. Query Merkl by `identifier=<vaultAddress>`.
 3. Check `aprRecord.breakdowns[].identifier`.
 4. Verify matching `campaigns[].campaignId` still exists after blacklist.

--- a/src/app/config/index.ts
+++ b/src/app/config/index.ts
@@ -20,7 +20,8 @@ export const config = {
   katanaChainId: 747474,
   // biome-ignore lint/style/noNonNullAssertion: temp
   rpcUrl: process.env.RPC_URL_KATANA!,
-  yearnApiUrl: process.env.YDAEMON_BASE_URI || 'https://ydaemon.yearn.fi',
+  kongApiUrl: process.env.KONG_BASE_URI || 'https://kong.yearn.fi/api/rest',
+  yDaemonApiUrl: process.env.YDAEMON_BASE_URI || 'https://ydaemon.yearn.fi',
   merklApiUrl: process.env.MERKL_BASE_URI || 'https://api.merkl.xyz',
   coingeckoApiUrl:
     process.env.COINGECKO_BASE_URI || 'https://api.coingecko.com/api/v3',

--- a/src/app/services/dataCache.test.ts
+++ b/src/app/services/dataCache.test.ts
@@ -6,7 +6,6 @@ const mocks = vi.hoisted(() => ({
   mockCalculateYearnVaultAPRs: vi.fn(),
   mockCalculateMorphoVaultAPRs: vi.fn(),
   mockCalculateSushiVaultAPRs: vi.fn(),
-  mockCalculateSteerPoints: vi.fn(),
   logVaultAprDebug: vi.fn(),
 }))
 
@@ -31,12 +30,6 @@ vi.mock('./aprCalcs/morphoAprCalculator', () => ({
 vi.mock('./aprCalcs/sushiAprCalculator', () => ({
   SushiAprCalculator: vi.fn().mockImplementation(() => ({
     calculateVaultAPRs: mocks.mockCalculateSushiVaultAPRs,
-  })),
-}))
-
-vi.mock('./pointsCalcs/steerPointsCalculator', () => ({
-  SteerPointsCalculator: vi.fn().mockImplementation(() => ({
-    calculateForVault: mocks.mockCalculateSteerPoints,
   })),
 }))
 
@@ -66,12 +59,10 @@ describe('DataCacheService.generateVaultAPRData', () => {
     mocks.mockCalculateYearnVaultAPRs.mockReset()
     mocks.mockCalculateMorphoVaultAPRs.mockReset()
     mocks.mockCalculateSushiVaultAPRs.mockReset()
-    mocks.mockCalculateSteerPoints.mockReset()
     mocks.logVaultAprDebug.mockReset()
     mocks.mockCalculateYearnVaultAPRs.mockResolvedValue({})
     mocks.mockCalculateMorphoVaultAPRs.mockResolvedValue({})
     mocks.mockCalculateSushiVaultAPRs.mockResolvedValue({})
-    mocks.mockCalculateSteerPoints.mockReturnValue(0)
   })
 
   it('returns fallback payload when all calculator results are empty', async () => {
@@ -198,6 +189,7 @@ describe('DataCacheService.generateVaultAPRData', () => {
     expect(aggregatedVault.apr?.extra?.katanaRewardsAPR).toBeCloseTo(0.1)
     expect(aggregatedVault.apr?.extra?.fixedRateKatanaRewards).toBe(0)
     expect(aggregatedVault.apr?.extra?.katanaBonusAPY).toBe(0)
+    expect(aggregatedVault.apr?.extra?.steerPointsPerDollar).toBe(0)
     expect(aggregatedVault.strategies[0].strategyRewardsAPR).toBe(0.04)
     expect(aggregatedVault.strategies[0].rewardToken).toEqual({
       address: '0x00000000000000000000000000000000000000bb',

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -5,7 +5,6 @@ import { YearnApiService } from './externalApis/yearnApi'
 import { MorphoAprCalculator } from './aprCalcs/morphoAprCalculator'
 import { SushiAprCalculator } from './aprCalcs/sushiAprCalculator'
 import { YearnAprCalculator } from './aprCalcs/yearnAprCalculator'
-import { SteerPointsCalculator } from './pointsCalcs/steerPointsCalculator'
 import { logVaultAprDebug } from './aprCalcs/debugLogger'
 import {
   type RewardCalculatorResult,
@@ -38,14 +37,12 @@ export class DataCacheService {
   private yearnAprCalculator: YearnAprCalculator
   private morphoAprCalculator: MorphoAprCalculator
   private sushiAprCalculator: SushiAprCalculator
-  private steerPointsCalculator: SteerPointsCalculator
 
   constructor() {
     this.yearnApi = new YearnApiService()
     this.yearnAprCalculator = new YearnAprCalculator()
     this.morphoAprCalculator = new MorphoAprCalculator()
     this.sushiAprCalculator = new SushiAprCalculator()
-    this.steerPointsCalculator = new SteerPointsCalculator()
   }
 
   async generateVaultAPRData(): Promise<APRDataCache> {
@@ -57,7 +54,7 @@ export class DataCacheService {
 
     if (vaults.length === 0) {
       throw new Error(
-        `No vaults returned from yDaemon (chainId=${config.katanaChainId})`,
+        `No vaults returned from Kong (chainId=${config.katanaChainId})`,
       )
     }
 
@@ -215,8 +212,7 @@ export class DataCacheService {
         fixedRateKatanaRewards: 0,
         katanaBonusAPY: vaultKatanaBonusAPY,
         katanaNativeYield,
-        steerPointsPerDollar:
-          this.steerPointsCalculator.calculateForVault(vault),
+        steerPointsPerDollar: 0,
       },
     }
 

--- a/src/app/services/externalApis/katanaPriceService.test.ts
+++ b/src/app/services/externalApis/katanaPriceService.test.ts
@@ -48,7 +48,7 @@ describe('KatanaPriceService', () => {
 
     expect(price).toBe(1.25)
     expect(mocks.fetchGet).toHaveBeenCalledWith(
-      `${config.yearnApiUrl}/prices/all`,
+      `${config.yDaemonApiUrl}/prices/all`,
     )
   })
 
@@ -72,7 +72,11 @@ describe('KatanaPriceService', () => {
     expect(mocks.fetchGet).toHaveBeenNthCalledWith(
       2,
       expect.stringContaining(`${config.coingeckoApiUrl}/simple/price`),
-      expect.objectContaining({ headers: undefined }),
+      expect.objectContaining({
+        headers: config.coingeckoApiKey
+          ? { 'x-cg-demo-api-key': config.coingeckoApiKey }
+          : undefined,
+      }),
     )
     expect(mocks.fetchGet).toHaveBeenNthCalledWith(
       2,
@@ -98,7 +102,7 @@ describe('KatanaPriceService', () => {
 
     expect(price).toBe(2.5)
     expect(mocks.fetchGet).toHaveBeenCalledWith(
-      `${config.yearnApiUrl}/prices/all`,
+      `${config.yDaemonApiUrl}/prices/all`,
     )
   })
 
@@ -119,7 +123,7 @@ describe('KatanaPriceService', () => {
 
     expect(price).toBe(2.5)
     expect(mocks.fetchGet).toHaveBeenCalledWith(
-      `${config.yearnApiUrl}/prices/all`,
+      `${config.yDaemonApiUrl}/prices/all`,
     )
   })
 

--- a/src/app/services/externalApis/katanaPriceService.ts
+++ b/src/app/services/externalApis/katanaPriceService.ts
@@ -67,7 +67,7 @@ export class KatanaPriceService {
   constructor() {
     this.coingeckoApiUrl = config.coingeckoApiUrl
     this.coingeckoKatanaCoinId = config.coingeckoKatanaCoinId
-    this.yearnApiUrl = config.yearnApiUrl
+    this.yearnApiUrl = config.yDaemonApiUrl
     this.coinGeckoHeaders = config.coingeckoApiKey
       ? { 'x-cg-demo-api-key': config.coingeckoApiKey }
       : undefined

--- a/src/app/services/externalApis/yearnApi.test.ts
+++ b/src/app/services/externalApis/yearnApi.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { config } from '../../config'
+
+const mocks = vi.hoisted(() => ({
+  fetchGet: vi.fn(),
+  logVaultAprDebug: vi.fn(),
+}))
+
+vi.stubGlobal('fetch', mocks.fetchGet)
+
+vi.mock('../aprCalcs/debugLogger', () => ({
+  logVaultAprDebug: mocks.logVaultAprDebug,
+}))
+
+import { YearnApiService } from './yearnApi'
+
+const makeOkResponse = (data: unknown) =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(data),
+  })
+
+describe('YearnApiService', () => {
+  beforeEach(() => {
+    mocks.fetchGet.mockReset()
+    mocks.logVaultAprDebug.mockReset()
+  })
+
+  it('fetches Katana Yearn vaults from Kong snapshots', async () => {
+    mocks.fetchGet.mockImplementation((url: string) => {
+      if (url.endsWith('/list/vaults/747474?origin=yearn')) {
+        return makeOkResponse([
+          {
+            chainId: 747474,
+            address: '0x00000000000000000000000000000000000000aa',
+            origin: 'yearn',
+            inclusion: { isKatana: true },
+          },
+          {
+            chainId: 747474,
+            address: '0x00000000000000000000000000000000000000bb',
+            origin: 'yearn',
+            inclusion: { isKatana: false },
+          },
+        ])
+      }
+
+      if (
+        url.endsWith(
+          '/snapshot/747474/0x00000000000000000000000000000000000000aa',
+        )
+      ) {
+        return makeOkResponse({
+          chainId: 747474,
+          address: '0x00000000000000000000000000000000000000aa',
+          name: 'vbUSDC yVault',
+          symbol: 'yvvbUSDC',
+          totalAssets: '1000000',
+          asset: {
+            address: '0x00000000000000000000000000000000000000cc',
+            name: 'Vault Bridge USDC',
+            symbol: 'vbUSDC',
+            decimals: '6',
+          },
+          meta: {
+            displayName: 'USDC yVault',
+          },
+          apy: {
+            net: 0.03,
+            weeklyNet: 0.02,
+            monthlyNet: 0.01,
+            inceptionNet: 0.04,
+            pricePerShare: '1000000',
+            weeklyPricePerShare: '990000',
+            monthlyPricePerShare: '980000',
+          },
+          tvl: {
+            close: 100,
+          },
+          fees: {
+            managementFee: 25,
+            performanceFee: 1000,
+          },
+          composition: [
+            {
+              address: '0x00000000000000000000000000000000000000dd',
+              name: 'Morpho Strategy',
+              status: 'active',
+              currentDebt: '42',
+              totalGain: '2',
+              totalLoss: '1',
+              lastReport: '123',
+              performanceFee: '0',
+            },
+          ],
+        })
+      }
+
+      throw new Error(`Unexpected fetch URL: ${url}`)
+    })
+
+    const service = new YearnApiService()
+    const vaults = await service.getVaults(config.katanaChainId)
+
+    expect(vaults).toHaveLength(1)
+    expect(vaults[0]).toMatchObject({
+      address: '0x00000000000000000000000000000000000000aa',
+      name: 'USDC yVault',
+      symbol: 'yvvbUSDC',
+      chainID: 747474,
+      apr: {
+        netAPR: 0.03,
+        fees: {
+          management: 25,
+          performance: 1000,
+        },
+      },
+      tvl: {
+        totalAssets: '1000000',
+        tvl: 100,
+        price: 0,
+      },
+    })
+    expect(vaults[0].strategies).toEqual([
+      {
+        address: '0x00000000000000000000000000000000000000dd',
+        name: 'Morpho Strategy',
+        status: 'active',
+        details: {
+          totalDebt: '42',
+          totalGain: '2',
+          totalLoss: '1',
+          lastReport: 123,
+          performanceFee: 0,
+        },
+      },
+    ])
+    expect(mocks.fetchGet).toHaveBeenCalledTimes(2)
+    expect(mocks.logVaultAprDebug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: 'vault_fetch',
+        reason: 'fetched_from_kong',
+      }),
+    )
+  })
+})

--- a/src/app/services/externalApis/yearnApi.ts
+++ b/src/app/services/externalApis/yearnApi.ts
@@ -1,37 +1,235 @@
 import { config } from '../../config'
-import type { YearnVault } from '../../types'
+import type {
+  YearnStrategy,
+  YearnStrategyDetails,
+  YearnVault,
+  YearnVaultAPY,
+  YearnVaultToken,
+  YearnVaultTVL,
+} from '../../types'
 import { logVaultAprDebug } from '../aprCalcs/debugLogger'
+
+type KongVaultListItem = {
+  address: string
+  chainId: number
+  origin?: string | null
+  inclusion?: Record<string, boolean>
+}
+
+type KongVaultCompositionItem = {
+  address?: string
+  name?: string
+  status?: string
+  currentDebt?: string
+  totalDebt?: string
+  totalGain?: string
+  totalLoss?: string
+  lastReport?: string | number
+  performanceFee?: string | number
+}
+
+type KongVaultAsset = {
+  address?: string
+  name?: string
+  symbol?: string
+  decimals?: string | number
+}
+
+type KongVaultSnapshot = {
+  address?: string
+  symbol?: string
+  name?: string
+  chainId?: number
+  totalAssets?: string
+  tvl?: { close?: number } | number
+  asset?: KongVaultAsset | null
+  meta?: {
+    displayName?: string
+    token?: KongVaultAsset
+  }
+  apy?: {
+    net?: number
+    weeklyNet?: number
+    monthlyNet?: number
+    inceptionNet?: number
+    pricePerShare?: string | number
+    weeklyPricePerShare?: string | number
+    monthlyPricePerShare?: string | number
+  }
+  performance?: {
+    oracle?: {
+      netAPR?: number
+    }
+    historical?: {
+      net?: number
+      weeklyNet?: number
+      monthlyNet?: number | null
+      inceptionNet?: number | null
+    }
+  }
+  fees?: {
+    managementFee?: number
+    performanceFee?: number
+  } | null
+  composition?: KongVaultCompositionItem[]
+}
+
+const isKongVaultListItem = (value: unknown): value is KongVaultListItem =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as KongVaultListItem).address === 'string' &&
+  typeof (value as KongVaultListItem).chainId === 'number'
+
+const isKongVaultSnapshot = (value: unknown): value is KongVaultSnapshot =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as KongVaultSnapshot).address === 'string'
+
+const toTrimmedBaseUrl = (url: string): string => url.replace(/\/+$/, '')
+
+const toNumber = (value: unknown): number => {
+  const parsed = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+const toStringValue = (value: unknown, fallback = '0'): string =>
+  value === null || value === undefined ? fallback : String(value)
+
+const isKatanaYearnVault = (vault: KongVaultListItem): boolean =>
+  vault.origin === 'yearn' && vault.inclusion?.isKatana === true
+
+const mapKongAssetToYearnToken = (
+  asset?: KongVaultAsset | null,
+): YearnVaultToken | undefined => {
+  if (!asset?.address || !asset.name || !asset.symbol) {
+    return undefined
+  }
+
+  return {
+    address: asset.address,
+    name: asset.name,
+    symbol: asset.symbol,
+    decimals: toNumber(asset.decimals),
+  }
+}
+
+const mapKongCompositionToYearnStrategy = (
+  strategy: KongVaultCompositionItem,
+): YearnStrategy | null => {
+  if (!strategy.address) {
+    return null
+  }
+
+  const details: YearnStrategyDetails = {
+    totalDebt: toStringValue(strategy.currentDebt ?? strategy.totalDebt),
+    totalGain: toStringValue(strategy.totalGain),
+    totalLoss: toStringValue(strategy.totalLoss),
+    lastReport: toNumber(strategy.lastReport),
+    performanceFee: toNumber(strategy.performanceFee),
+  }
+
+  return {
+    address: strategy.address,
+    name: strategy.name || 'Unknown',
+    status: strategy.status,
+    details,
+  }
+}
+
+const mapKongAprToYearnApr = (snapshot: KongVaultSnapshot): YearnVaultAPY => {
+  const historical = snapshot.performance?.historical
+  const apy = snapshot.apy
+
+  return {
+    netAPR:
+      apy?.net ??
+      historical?.net ??
+      snapshot.performance?.oracle?.netAPR ??
+      0,
+    fees: snapshot.fees
+      ? {
+          management: toNumber(snapshot.fees.managementFee),
+          performance: toNumber(snapshot.fees.performanceFee),
+        }
+      : undefined,
+    points: {
+      weekAgo: toNumber(apy?.weeklyNet ?? historical?.weeklyNet),
+      monthAgo: toNumber(apy?.monthlyNet ?? historical?.monthlyNet),
+      inception: toNumber(apy?.inceptionNet ?? historical?.inceptionNet),
+    },
+    pricePerShare: {
+      today: toNumber(apy?.pricePerShare),
+      weekAgo: toNumber(apy?.weeklyPricePerShare),
+      monthAgo: toNumber(apy?.monthlyPricePerShare),
+    },
+  }
+}
+
+const mapKongTvlToYearnTvl = (snapshot: KongVaultSnapshot): YearnVaultTVL => ({
+  totalAssets: toStringValue(snapshot.totalAssets),
+  tvl: typeof snapshot.tvl === 'number'
+    ? snapshot.tvl
+    : toNumber(snapshot.tvl?.close),
+  price: 0,
+})
+
+const mapKongSnapshotToYearnVault = (
+  snapshot: KongVaultSnapshot,
+  chainId: number,
+): YearnVault | null => {
+  if (!snapshot.address || !snapshot.name || !snapshot.symbol) {
+    return null
+  }
+
+  const token = mapKongAssetToYearnToken(snapshot.asset ?? snapshot.meta?.token)
+  const strategies = (snapshot.composition || [])
+    .map(mapKongCompositionToYearnStrategy)
+    .filter((strategy): strategy is YearnStrategy => strategy !== null)
+
+  return {
+    address: snapshot.address,
+    symbol: snapshot.symbol,
+    name: snapshot.meta?.displayName || snapshot.name,
+    chainID: snapshot.chainId ?? chainId,
+    strategies,
+    apr: mapKongAprToYearnApr(snapshot),
+    tvl: mapKongTvlToYearnTvl(snapshot),
+    ...(token ? { token } : {}),
+  }
+}
 
 export class YearnApiService {
   private apiUrl: string
 
   constructor() {
-    this.apiUrl = config.yearnApiUrl
+    this.apiUrl = toTrimmedBaseUrl(config.kongApiUrl)
   }
 
   async getVaults(
-    chainId: number = config.katanaChainId
+    chainId: number = config.katanaChainId,
   ): Promise<YearnVault[]> {
     try {
-      const params = new URLSearchParams({
-        hideAlways: 'true',
-        orderBy: 'featuringScore',
-        orderDirection: 'desc',
-        strategiesDetails: 'withDetails',
-        strategiesCondition: 'inQueue',
-        chainIDs: chainId.toString(),
-        limit: '2500',
-      })
+      const listResponse = await fetch(
+        `${this.apiUrl}/list/vaults/${chainId}?origin=yearn`,
+      )
 
-      const url: string = `${this.apiUrl}/vaults/katana?${params}`
-
-      const response = await fetch(url)
-
-      if (!response.ok) {
-        throw new Error(`HTTP error fetching vaults from yDaemon: ${response.status}`)
+      if (!listResponse.ok) {
+        throw new Error(`HTTP error fetching vault list from Kong: ${listResponse.status}`)
       }
 
-      const vaults: YearnVault[] = (await response.json() as YearnVault[]) || []
+      const vaultList = ((await listResponse.json()) as unknown[] || [])
+        .filter(isKongVaultListItem)
+        .filter(isKatanaYearnVault)
+
+      const snapshots = await Promise.all(
+        vaultList.map((vault) => this.getVaultSnapshot(chainId, vault.address)),
+      )
+
+      const vaults = snapshots
+        .map((snapshot) =>
+          snapshot ? mapKongSnapshotToYearnVault(snapshot, chainId) : null
+        )
+        .filter((vault): vault is YearnVault => vault !== null)
 
       for (const vault of vaults) {
         logVaultAprDebug({
@@ -41,29 +239,24 @@ export class YearnApiService {
           vaultSymbol: vault.symbol,
           chainId,
           totalVaults: vaults.length,
-          reason: 'fetched_from_ydaemon',
+          reason: 'fetched_from_kong',
         })
       }
 
       return vaults
     } catch (error) {
-      console.error('Error fetching vaults from yDaemon:', error)
+      console.error('Error fetching vaults from Kong:', error)
       return []
     }
   }
 
   async getVaultByAddress(
     vaultAddress: string,
-    chainId: number = config.katanaChainId
+    chainId: number = config.katanaChainId,
   ): Promise<YearnVault | null> {
     try {
-      const vaults: YearnVault[] = await this.getVaults(chainId)
-      return (
-        vaults.find(
-          (vault: YearnVault): boolean =>
-            vault.address.toLowerCase() === vaultAddress.toLowerCase()
-        ) || null
-      )
+      const snapshot = await this.getVaultSnapshot(chainId, vaultAddress)
+      return snapshot ? mapKongSnapshotToYearnVault(snapshot, chainId) : null
     } catch (error) {
       console.error('Error fetching vault by address:', error)
       return null
@@ -114,5 +307,23 @@ export class YearnApiService {
 
   getAutoCompoundedAPY(vault: YearnVault): number {
     return vault.apr?.netAPR || 0
+  }
+
+  private async getVaultSnapshot(
+    chainId: number,
+    vaultAddress: string,
+  ): Promise<KongVaultSnapshot | null> {
+    const response = await fetch(
+      `${this.apiUrl}/snapshot/${chainId}/${vaultAddress.toLowerCase()}`,
+    )
+
+    if (!response.ok) {
+      throw new Error(
+        `HTTP error fetching vault snapshot from Kong: ${response.status}`,
+      )
+    }
+
+    const snapshot = await response.json()
+    return isKongVaultSnapshot(snapshot) ? snapshot : null
   }
 }


### PR DESCRIPTION
## Summary

I realized that this service uses yDaemon instead of kong to get vault information. This PR changes the service to pull vault data from Kong, but still gets prices from yDaemon. When prices are migrated to a new service, we can incorporate that.

We also zero out steer rewards as that program has ended.

## To Test
- `/api/vaults` output should be the same as current API.
- Steer points values should always be 0.
