### PR TITLE
Update to Kong update: keep fields matching ydaemon

### DIFF
--- a/docs/api-integration-guide.md
+++ b/docs/api-integration-guide.md
@@ -190,7 +190,7 @@ APR units:
 - `apr.extra.katanaAppRewardsAPR` from Yearn vault-level rewards
 - `apr.extra.fixedRateKatanaRewards` (legacy compatibility field; fixed-rate KAT rewards have ended and this is always `0`)
 - `apr.extra.katanaBonusAPY` (`0` post-TGE, kept for compatibility)
-- `apr.extra.katanaNativeYield` (`vault.apr.netAPR`)
+- `apr.extra.katanaNativeYield` (`vault.apr.netAPR`, mapped from Kong monthly net APY for yDaemon compatibility)
 - `apr.extra.steerPointsPerDollar` (`0`; legacy field kept after the points program ended)
 
 Weighting notes:

--- a/src/app/api/webhook/route.ts
+++ b/src/app/api/webhook/route.ts
@@ -88,7 +88,7 @@ function jsonResponseWithBigInt(data: unknown): Response {
 
 const dataCacheService = new DataCacheService()
 
-function toFiniteNumber(value: number | undefined): number | undefined {
+function toFiniteNumber(value: number | null | undefined): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined
 }
 

--- a/src/app/quick-apys/page.tsx
+++ b/src/app/quick-apys/page.tsx
@@ -22,7 +22,7 @@ type VaultDisplay = {
   strategies: StrategyDisplay[]
 }
 
-const formatPercent = (value: number | undefined): string =>
+const formatPercent = (value: number | null | undefined): string =>
   ((value || 0) * 100).toFixed(2)
 
 const parseVaultResponse = (data: unknown): YearnVault[] => {

--- a/src/app/services/dataCache.test.ts
+++ b/src/app/services/dataCache.test.ts
@@ -294,8 +294,8 @@ describe('DataCacheService.generateVaultAPRData', () => {
       address: STRATEGY_ADDRESS,
       strategyRewardsAPR: 0,
     })
-    expect(data[vault.address].strategies[0].rewardToken).toBeUndefined()
-    expect(data[vault.address].strategies[0].underlyingContract).toBeUndefined()
+    expect(data[vault.address].strategies[0].rewardToken).toBeNull()
+    expect(data[vault.address].strategies[0].underlyingContract).toBeNull()
     expect(data[vault.address].apr?.extra?.katanaAppRewardsAPR).toBe(0)
     expect(data[vault.address].apr?.extra?.katanaRewardsAPR).toBe(0)
   })

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -168,18 +168,30 @@ export class DataCacheService {
       const strategyRewards = strategyAddress
         ? strategyRewardsByAddress[strategyAddress]
         : undefined
+      const strategyRewardsAPR = strategyRewards
+        ? strategyRewards.rawApr > 0
+          ? strategyRewards.rawApr
+          : strategy.strategyRewardsAPR ?? strategyRewards.rawApr
+        : strategy.strategyRewardsAPR ?? null
 
       return {
         ...strategy,
         ...(strategyRewards
           ? {
-              strategyRewardsAPR: strategyRewards.rawApr,
+              strategyRewardsAPR,
               rewardToken: strategyRewards.rewardToken
                 ? { ...strategyRewards.rewardToken }
-                : undefined,
-              underlyingContract: strategyRewards.underlyingContract,
+                : strategy.rewardToken ?? null,
+              underlyingContract:
+                strategyRewards.underlyingContract ??
+                strategy.underlyingContract ??
+                null,
             }
-          : {}),
+          : {
+              strategyRewardsAPR: strategy.strategyRewardsAPR ?? null,
+              rewardToken: strategy.rewardToken ?? null,
+              underlyingContract: strategy.underlyingContract ?? null,
+            }),
       }
     })
 
@@ -207,6 +219,8 @@ export class DataCacheService {
       ...vault.apr,
       extra: {
         ...(vault.apr?.extra || {}),
+        stakingRewardsAPR: null,
+        gammaRewardAPR: null,
         katanaRewardsAPR: yearnVaultRewards || 0, // legacy field
         katanaAppRewardsAPR: yearnVaultRewards || 0,
         fixedRateKatanaRewards: 0,

--- a/src/app/services/externalApis/yearnApi.test.ts
+++ b/src/app/services/externalApis/yearnApi.test.ts
@@ -57,6 +57,7 @@ describe('YearnApiService', () => {
           name: 'vbUSDC yVault',
           symbol: 'yvvbUSDC',
           totalAssets: '1000000',
+          totalDebt: '100',
           asset: {
             address: '0x00000000000000000000000000000000000000cc',
             name: 'Vault Bridge USDC',
@@ -110,16 +111,22 @@ describe('YearnApiService', () => {
       symbol: 'yvvbUSDC',
       chainID: 747474,
       apr: {
-        netAPR: 0.03,
+        type: 'v3:averaged',
+        netAPR: 0.01,
         fees: {
-          management: 25,
-          performance: 1000,
+          management: 0.0025,
+          performance: 0.1,
+        },
+        pricePerShare: {
+          today: 1,
+          weekAgo: 0.99,
+          monthAgo: 0.98,
         },
       },
       tvl: {
         totalAssets: '1000000',
         tvl: 100,
-        price: 0,
+        price: 100,
       },
     })
     expect(vaults[0].strategies).toEqual([
@@ -127,12 +134,17 @@ describe('YearnApiService', () => {
         address: '0x00000000000000000000000000000000000000dd',
         name: 'Morpho Strategy',
         status: 'active',
+        netAPR: null,
+        strategyRewardsAPR: null,
+        rewardToken: null,
+        underlyingContract: null,
         details: {
           totalDebt: '42',
           totalGain: '2',
           totalLoss: '1',
           lastReport: 123,
           performanceFee: 0,
+          debtRatio: 4200,
         },
       },
     ])

--- a/src/app/services/externalApis/yearnApi.ts
+++ b/src/app/services/externalApis/yearnApi.ts
@@ -8,6 +8,7 @@ import type {
   YearnVaultTVL,
 } from '../../types'
 import { logVaultAprDebug } from '../aprCalcs/debugLogger'
+import { CANONICAL_KAT_ADDRESS } from '../katanaRewardTokens'
 
 type KongVaultListItem = {
   address: string
@@ -21,17 +22,25 @@ type KongVaultCompositionItem = {
   name?: string
   status?: string
   currentDebt?: string
+  maxDebt?: string
   totalDebt?: string
   totalGain?: string
   totalLoss?: string
   lastReport?: string | number
   performanceFee?: string | number
+  latestReportApr?: number | null
+  performance?: {
+    estimated?: {
+      components?: Record<string, number | string | null>
+    }
+  }
 }
 
 type KongVaultAsset = {
   address?: string
   name?: string
   symbol?: string
+  description?: string
   decimals?: string | number
 }
 
@@ -40,7 +49,9 @@ type KongVaultSnapshot = {
   symbol?: string
   name?: string
   chainId?: number
+  decimals?: string | number
   totalAssets?: string
+  totalDebt?: string
   tvl?: { close?: number } | number
   asset?: KongVaultAsset | null
   meta?: {
@@ -92,8 +103,67 @@ const toNumber = (value: unknown): number => {
   return Number.isFinite(parsed) ? parsed : 0
 }
 
+const toFiniteNumberOrNull = (value: unknown): number | null => {
+  if (value === null || value === undefined || value === '') {
+    return null
+  }
+
+  const parsed = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
 const toStringValue = (value: unknown, fallback = '0'): string =>
   value === null || value === undefined ? fallback : String(value)
+
+const normalizeBasisPoints = (value: unknown): number => toNumber(value) / 10_000
+
+const normalizeShareValue = (
+  value: unknown,
+  decimals: number,
+): number => {
+  if (value === null || value === undefined) {
+    return 0
+  }
+
+  try {
+    return Number(BigInt(String(value))) / 10 ** decimals
+  } catch {
+    return toNumber(value)
+  }
+}
+
+const calculateDebtRatio = (
+  strategyDebt: unknown,
+  vaultDebt: unknown,
+): number | undefined => {
+  try {
+    const debt = BigInt(String(strategyDebt ?? '0'))
+    const totalDebt = BigInt(String(vaultDebt ?? '0'))
+    if (debt <= BigInt(0) || totalDebt <= BigInt(0)) {
+      return undefined
+    }
+
+    return Number(
+      (debt * BigInt(10_000) + totalDebt / BigInt(2)) / totalDebt,
+    )
+  } catch {
+    return undefined
+  }
+}
+
+const calculateTokenPrice = (
+  totalAssets: unknown,
+  tvl: number,
+  decimals: number,
+): number => {
+  const normalizedAssets = normalizeShareValue(totalAssets, decimals)
+  return normalizedAssets > 0 ? tvl / normalizedAssets : 0
+}
+
+const toPositiveFiniteNumberOrNull = (value: unknown): number | null => {
+  const parsed = toFiniteNumberOrNull(value)
+  return parsed && parsed > 0 ? parsed : null
+}
 
 const isKatanaYearnVault = (vault: KongVaultListItem): boolean =>
   vault.origin === 'yearn' && vault.inclusion?.isKatana === true
@@ -110,28 +180,49 @@ const mapKongAssetToYearnToken = (
     name: asset.name,
     symbol: asset.symbol,
     decimals: toNumber(asset.decimals),
+    description: asset.description || '',
   }
 }
 
 const mapKongCompositionToYearnStrategy = (
   strategy: KongVaultCompositionItem,
+  snapshot: KongVaultSnapshot,
 ): YearnStrategy | null => {
   if (!strategy.address) {
     return null
   }
 
+  const totalDebt = toStringValue(strategy.currentDebt ?? strategy.totalDebt)
+  const estimatedKatRewardsAPR = toFiniteNumberOrNull(
+    strategy.performance?.estimated?.components?.katRewardsAPR,
+  )
   const details: YearnStrategyDetails = {
-    totalDebt: toStringValue(strategy.currentDebt ?? strategy.totalDebt),
+    totalDebt,
     totalGain: toStringValue(strategy.totalGain),
     totalLoss: toStringValue(strategy.totalLoss),
     lastReport: toNumber(strategy.lastReport),
     performanceFee: toNumber(strategy.performanceFee),
   }
+  const debtRatio = calculateDebtRatio(totalDebt, snapshot.totalDebt)
+  if (debtRatio !== undefined) {
+    details.debtRatio = debtRatio
+  }
 
   return {
     address: strategy.address,
     name: strategy.name || 'Unknown',
-    status: strategy.status,
+    status: totalDebt === '0' ? 'unallocated' : strategy.status,
+    netAPR: toPositiveFiniteNumberOrNull(strategy.latestReportApr),
+    strategyRewardsAPR: estimatedKatRewardsAPR,
+    rewardToken:
+      estimatedKatRewardsAPR !== null && estimatedKatRewardsAPR > 0
+        ? {
+            address: CANONICAL_KAT_ADDRESS,
+            symbol: 'KAT',
+            decimals: 18,
+          }
+        : null,
+    underlyingContract: null,
     details,
   }
 }
@@ -139,17 +230,21 @@ const mapKongCompositionToYearnStrategy = (
 const mapKongAprToYearnApr = (snapshot: KongVaultSnapshot): YearnVaultAPY => {
   const historical = snapshot.performance?.historical
   const apy = snapshot.apy
+  const shareDecimals = toNumber(snapshot.decimals ?? snapshot.asset?.decimals)
 
   return {
+    type: 'v3:averaged',
     netAPR:
+      apy?.monthlyNet ??
+      historical?.monthlyNet ??
       apy?.net ??
       historical?.net ??
       snapshot.performance?.oracle?.netAPR ??
       0,
     fees: snapshot.fees
       ? {
-          management: toNumber(snapshot.fees.managementFee),
-          performance: toNumber(snapshot.fees.performanceFee),
+          management: normalizeBasisPoints(snapshot.fees.managementFee),
+          performance: normalizeBasisPoints(snapshot.fees.performanceFee),
         }
       : undefined,
     points: {
@@ -158,20 +253,46 @@ const mapKongAprToYearnApr = (snapshot: KongVaultSnapshot): YearnVaultAPY => {
       inception: toNumber(apy?.inceptionNet ?? historical?.inceptionNet),
     },
     pricePerShare: {
-      today: toNumber(apy?.pricePerShare),
-      weekAgo: toNumber(apy?.weeklyPricePerShare),
-      monthAgo: toNumber(apy?.monthlyPricePerShare),
+      today: normalizeShareValue(apy?.pricePerShare, shareDecimals),
+      weekAgo: normalizeShareValue(
+        apy?.weeklyPricePerShare,
+        shareDecimals,
+      ),
+      monthAgo: normalizeShareValue(
+        apy?.monthlyPricePerShare,
+        shareDecimals,
+      ),
+    },
+    forwardAPR: {
+      type: '',
+      netAPR: null,
+      composite: {
+        boost: null,
+        poolAPY: null,
+        boostedAPR: null,
+        baseAPR: null,
+        cvxAPR: null,
+        rewardsAPR: null,
+      },
     },
   }
 }
 
-const mapKongTvlToYearnTvl = (snapshot: KongVaultSnapshot): YearnVaultTVL => ({
-  totalAssets: toStringValue(snapshot.totalAssets),
-  tvl: typeof snapshot.tvl === 'number'
+const mapKongTvlToYearnTvl = (snapshot: KongVaultSnapshot): YearnVaultTVL => {
+  const tvl = typeof snapshot.tvl === 'number'
     ? snapshot.tvl
-    : toNumber(snapshot.tvl?.close),
-  price: 0,
-})
+    : toNumber(snapshot.tvl?.close)
+
+  return {
+    totalAssets: toStringValue(snapshot.totalAssets),
+    tvl,
+    price: calculateTokenPrice(
+      snapshot.totalAssets,
+      tvl,
+      toNumber(snapshot.asset?.decimals ?? snapshot.decimals),
+    ),
+  }
+}
 
 const mapKongSnapshotToYearnVault = (
   snapshot: KongVaultSnapshot,
@@ -183,7 +304,7 @@ const mapKongSnapshotToYearnVault = (
 
   const token = mapKongAssetToYearnToken(snapshot.asset ?? snapshot.meta?.token)
   const strategies = (snapshot.composition || [])
-    .map(mapKongCompositionToYearnStrategy)
+    .map((strategy) => mapKongCompositionToYearnStrategy(strategy, snapshot))
     .filter((strategy): strategy is YearnStrategy => strategy !== null)
 
   return {

--- a/src/app/types/yearn.ts
+++ b/src/app/types/yearn.ts
@@ -18,14 +18,16 @@ export interface YearnStrategy {
   address: string
   name: string
   status?: string
-  netAPR?: number
-  strategyRewardsAPR?: number
-  rewardToken?: YearnRewardToken
-  underlyingContract?: string
+  netAPR?: number | null
+  strategyRewardsAPR?: number | null
+  rewardToken?: YearnRewardToken | null
+  underlyingContract?: string | null
   details?: YearnStrategyDetails
 }
 
 export interface YearnVaultExtra {
+  stakingRewardsAPR?: number | null
+  gammaRewardAPR?: number | null
   katanaRewardsAPR?: number // legacy field
   katanaAppRewardsAPR?: number
   fixedRateKatanaRewards?: number
@@ -59,6 +61,18 @@ export interface YearnVaultAPY {
   points?: YearnVaultPoints
   pricePerShare?: YearnVaultPricePerShare
   extra?: YearnVaultExtra
+  forwardAPR?: {
+    type: string
+    netAPR: number | null
+    composite: {
+      boost: number | null
+      poolAPY: number | null
+      boostedAPR: number | null
+      baseAPR: number | null
+      cvxAPR: number | null
+      rewardsAPR: number | null
+    }
+  }
 }
 
 export interface YearnVaultTVL {


### PR DESCRIPTION
continuation of #42 that fixes compatibility issues where some fields the came from yDaemon were being dropped. 

from that PR:

## Description

I realized that this service uses yDaemon instead of kong to get vault information. This PR changes the service to pull vault data from Kong, but still gets prices from yDaemon. When prices are migrated to a new service, we can incorporate that.

We also zero out steer rewards as that program has ended.

## To Test

- /api/vaults output should be the same as current API. Same fields and values. Ordering can be different.
- Steer points values should always be 0.
 