### PR TITLE
Fix Merkl ERC20_MAPPING vault rewards and base debtRatio on totalAssets

### DIFF
--- a/src/app/services/aprCalcs/yearnAprCalculator.test.ts
+++ b/src/app/services/aprCalcs/yearnAprCalculator.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { YearnVault } from '../../types'
+
+const mocks = vi.hoisted(() => ({
+  getYearnVaultRewardOpportunities: vi.fn(),
+}))
+
+vi.mock('../externalApis/merklApi', () => ({
+  MerklApiService: vi.fn().mockImplementation(() => ({
+    getYearnVaultRewardOpportunities: mocks.getYearnVaultRewardOpportunities,
+  })),
+}))
+
+vi.mock('../externalApis/yearnApi', () => ({
+  YearnApiService: vi.fn().mockImplementation(() => ({})),
+}))
+
+vi.mock('../contractReader', () => ({
+  ContractReaderService: vi.fn().mockImplementation(() => ({})),
+}))
+
+import { YearnAprCalculator } from './yearnAprCalculator'
+
+const VAULT_ADDRESS = '0x00000000000000000000000000000000000000aa'
+const CANONICAL_KAT_ADDRESS = '0x7F1f4b4b29f5058fA32CC7a97141b8D7e5ABDC2d'
+
+const vault: YearnVault = {
+  address: VAULT_ADDRESS,
+  symbol: 'yvvbUSDC',
+  name: 'USDC yVault',
+  chainID: 747474,
+  token: {
+    address: '0x00000000000000000000000000000000000000bb',
+    name: 'Vault Bridge USDC',
+    symbol: 'vbUSDC',
+    description: '',
+    decimals: 6,
+  },
+  tvl: {
+    totalAssets: '100',
+    tvl: 100,
+    price: 1,
+  },
+  strategies: [],
+  apr: {
+    netAPR: 0,
+  },
+}
+
+describe('YearnAprCalculator', () => {
+  beforeEach(() => {
+    mocks.getYearnVaultRewardOpportunities.mockReset()
+  })
+
+  it('includes ERC20_MAPPING opportunities for vault-level Yearn rewards', async () => {
+    mocks.getYearnVaultRewardOpportunities.mockResolvedValue([
+      {
+        id: '166629803376662999264',
+        identifier: VAULT_ADDRESS,
+        name: 'Yearn ERC20 mapping reward',
+        type: 'ERC20_MAPPING',
+        campaigns: [
+          {
+            campaignId: 'mapping-campaign',
+            rewardToken: {
+              address: CANONICAL_KAT_ADDRESS,
+              symbol: 'KAT',
+              decimals: 18,
+            },
+          },
+        ],
+        aprRecord: {
+          breakdowns: [{ identifier: 'mapping-campaign', value: 7.5 }],
+        },
+      },
+    ])
+
+    const calculator = new YearnAprCalculator()
+    const results = await calculator.calculateVaultAPRs([vault])
+
+    expect(mocks.getYearnVaultRewardOpportunities).toHaveBeenCalledOnce()
+    expect(results[VAULT_ADDRESS]).toEqual([
+      {
+        vaultName: 'USDC yVault',
+        vaultAddress: VAULT_ADDRESS,
+        poolType: 'yearn',
+        breakdown: {
+          apr: 7.5,
+          token: {
+            address: CANONICAL_KAT_ADDRESS,
+            symbol: 'KAT',
+            decimals: 18,
+          },
+          weight: 0,
+        },
+      },
+    ])
+  })
+})

--- a/src/app/services/aprCalcs/yearnAprCalculator.ts
+++ b/src/app/services/aprCalcs/yearnAprCalculator.ts
@@ -33,7 +33,7 @@ export class YearnAprCalculator implements APRCalculator {
     vaults: YearnVault[]
   ): Promise<Record<string, RewardCalculatorResult[]>> {
     const yearnOpportunities =
-      await this.merklApi.getErc20LogProcessorOpportunities()
+      await this.merklApi.getYearnVaultRewardOpportunities()
 
     // Calculate APRs for each vault
     const resultEntries = vaults.map((vault) => {

--- a/src/app/services/externalApis/merklApi.test.ts
+++ b/src/app/services/externalApis/merklApi.test.ts
@@ -165,6 +165,163 @@ describe('MerklApiService', () => {
     )
   })
 
+  it('combines Yearn vault reward opportunities from log processor and mapping types', async () => {
+    const vaultAddress = '0x93Fec6639717b6215A48E5a72a162C50DCC40d68'
+    const duplicateCampaignId = 'campaign-log'
+    const mappingCampaignId = 'campaign-mapping'
+    const blacklistedCampaignId =
+      '0xc5a22d022154d5c64ff14b2f4071f134eb83cf159f9f846ad0ba0908a755e86d'
+
+    mocks.fetchGet
+      .mockImplementationOnce(() =>
+        makeOkResponse([
+          {
+            chainId: 747474,
+            name: 'Yearn ERC20 log processor reward',
+            tvl: 1_000_000,
+            status: 'LIVE',
+            type: 'ERC20LOGPROCESSOR',
+            identifier: vaultAddress,
+            campaigns: [
+              {
+                campaignId: duplicateCampaignId,
+                amount: '1',
+                rewardToken: {
+                  address: '0x6E9C1F88a960fE63387eb4b71BC525a9313d8461',
+                  symbol: 'KAT',
+                  decimals: 18,
+                  price: 1,
+                },
+                startTimestamp: 0,
+                endTimestamp: 0,
+              },
+            ],
+            aprRecord: {
+              breakdowns: [{ identifier: duplicateCampaignId, value: 1.5 }],
+            },
+          },
+        ]),
+      )
+      .mockImplementationOnce(() =>
+        makeOkResponse([
+          {
+            id: '166629803376662999264',
+            chainId: 747474,
+            name: 'Yearn ERC20 mapping reward',
+            tvl: 1_000_000,
+            status: 'LIVE',
+            type: 'ERC20_MAPPING',
+            identifier: vaultAddress,
+            campaigns: [
+              {
+                campaignId: duplicateCampaignId,
+                amount: '1',
+                rewardToken: {
+                  address: '0x6E9C1F88a960fE63387eb4b71BC525a9313d8461',
+                  symbol: 'KAT',
+                  decimals: 18,
+                  price: 1,
+                },
+                startTimestamp: 0,
+                endTimestamp: 0,
+              },
+              {
+                campaignId: mappingCampaignId,
+                amount: '1',
+                rewardToken: {
+                  address: '0x6E9C1F88a960fE63387eb4b71BC525a9313d8461',
+                  symbol: 'KAT',
+                  decimals: 18,
+                  price: 1,
+                },
+                startTimestamp: 0,
+                endTimestamp: 0,
+              },
+              {
+                campaignId: blacklistedCampaignId,
+                amount: '1',
+                rewardToken: {
+                  address: '0x6E9C1F88a960fE63387eb4b71BC525a9313d8461',
+                  symbol: 'KAT',
+                  decimals: 18,
+                  price: 1,
+                },
+                startTimestamp: 0,
+                endTimestamp: 0,
+              },
+            ],
+            aprRecord: {
+              breakdowns: [
+                { identifier: duplicateCampaignId, value: 1.5 },
+                { identifier: mappingCampaignId, value: 2.25 },
+                { identifier: blacklistedCampaignId, value: 99 },
+              ],
+            },
+          },
+        ]),
+      )
+
+    const service = new MerklApiService('https://merkl-proxy.internal')
+    const opportunities = await service.getYearnVaultRewardOpportunities()
+
+    expect(mocks.fetchGet).toHaveBeenCalledTimes(2)
+    expect(mocks.fetchGet).toHaveBeenNthCalledWith(
+      1,
+      expect.stringMatching(/\/v4\/opportunities\?.*type=ERC20LOGPROCESSOR/),
+    )
+    expect(mocks.fetchGet).toHaveBeenNthCalledWith(
+      2,
+      expect.stringMatching(/\/v4\/opportunities\?.*type=ERC20_MAPPING/),
+    )
+    expect(opportunities).toHaveLength(1)
+    expect(
+      opportunities[0].campaigns?.map((campaign) => campaign.campaignId),
+    ).toEqual([duplicateCampaignId, mappingCampaignId])
+    expect(
+      opportunities[0].aprRecord?.breakdowns?.map(
+        (breakdown) => breakdown.identifier,
+      ),
+    ).toContain(mappingCampaignId)
+    expect(mocks.logVaultAprDebug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: 'blacklist_filter',
+        vaultAddress,
+        blacklistedCampaignIds: [blacklistedCampaignId],
+        blacklistedAprBreakdownCampaignIds: [blacklistedCampaignId],
+      }),
+    )
+  })
+
+  it('keeps log processor opportunities when mapping opportunities fail', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const logProcessorOpportunity = {
+      chainId: 747474,
+      name: 'Yearn ERC20 log processor reward',
+      tvl: 1_000_000,
+      status: 'LIVE',
+      type: 'ERC20LOGPROCESSOR',
+      identifier: '0x93Fec6639717b6215A48E5a72a162C50DCC40d68',
+      campaigns: [],
+    }
+
+    mocks.fetchGet
+      .mockImplementationOnce(() => makeOkResponse([logProcessorOpportunity]))
+      .mockImplementationOnce(() => makeErrorResponse(500))
+
+    const service = new MerklApiService('https://merkl-proxy.internal')
+    const opportunities = await service.getYearnVaultRewardOpportunities()
+
+    expect(opportunities).toEqual([logProcessorOpportunity])
+    expect(consoleError).toHaveBeenCalledWith(
+      'Error fetching ERC20_MAPPING opportunities:',
+      expect.any(Error),
+    )
+
+    consoleError.mockRestore()
+  })
+
   it('logs when a blacklist removes the active APR-breakdown campaign', async () => {
     const vaultAddress = '0x93Fec6639717b6215A48E5a72a162C50DCC40d68'
     const blacklistedCampaignId =

--- a/src/app/services/externalApis/merklApi.ts
+++ b/src/app/services/externalApis/merklApi.ts
@@ -26,8 +26,29 @@ const extractAddressFromIdentifier = (
 }
 
 const MERKL_PAGE_SIZE = 100
+const YEARN_VAULT_REWARD_OPPORTUNITY_TYPES = [
+  'ERC20LOGPROCESSOR',
+  'ERC20_MAPPING',
+] as const
 
 const normalizeApiUrl = (apiUrl: string): string => apiUrl.replace(/\/+$/, '')
+
+type MerklCampaign = NonNullable<MerklOpportunity['campaigns']>[number]
+type MerklAprBreakdown = NonNullable<
+  NonNullable<MerklOpportunity['aprRecord']>['breakdowns']
+>[number]
+
+const getCampaignKey = (campaign: MerklCampaign): string =>
+  campaign.campaignId?.toLowerCase() ||
+  [
+    campaign.rewardToken.address.toLowerCase(),
+    campaign.amount,
+    campaign.startTimestamp,
+    campaign.endTimestamp,
+  ].join('|')
+
+const getAprBreakdownKey = (breakdown: MerklAprBreakdown): string =>
+  breakdown.identifier?.toLowerCase() || String(breakdown.value)
 
 export class MerklApiService {
   private apiUrls: string[]
@@ -106,6 +127,71 @@ export class MerklApiService {
     return Array.isArray(responseData)
       ? responseData
       : responseData.opportunities || []
+  }
+
+  private mergeOpportunities(
+    opportunities: MerklOpportunity[],
+  ): MerklOpportunity[] {
+    const mergedOpportunities = new Map<string, MerklOpportunity>()
+
+    for (const opportunity of opportunities) {
+      const key = opportunity.identifier.toLowerCase()
+      const existingOpportunity = mergedOpportunities.get(key)
+
+      if (!existingOpportunity) {
+        const copiedOpportunity: MerklOpportunity = {
+          ...opportunity,
+          campaigns: opportunity.campaigns ? [...opportunity.campaigns] : [],
+        }
+
+        if (opportunity.aprRecord) {
+          copiedOpportunity.aprRecord = {
+            ...opportunity.aprRecord,
+            breakdowns: opportunity.aprRecord?.breakdowns
+              ? [...opportunity.aprRecord.breakdowns]
+              : [],
+          }
+        }
+
+        mergedOpportunities.set(key, copiedOpportunity)
+        continue
+      }
+
+      const campaignKeys = new Set(
+        existingOpportunity.campaigns?.map(getCampaignKey) || [],
+      )
+      const additionalCampaigns = opportunity.campaigns?.filter((campaign) => {
+        const campaignKey = getCampaignKey(campaign)
+        if (campaignKeys.has(campaignKey)) {
+          return false
+        }
+        campaignKeys.add(campaignKey)
+        return true
+      }) || []
+
+      const existingBreakdowns = existingOpportunity.aprRecord?.breakdowns || []
+      const breakdownKeys = new Set(existingBreakdowns.map(getAprBreakdownKey))
+      const additionalBreakdowns =
+        opportunity.aprRecord?.breakdowns?.filter((breakdown) => {
+          const breakdownKey = getAprBreakdownKey(breakdown)
+          if (breakdownKeys.has(breakdownKey)) {
+            return false
+          }
+          breakdownKeys.add(breakdownKey)
+          return true
+        }) || []
+
+      existingOpportunity.campaigns = [
+        ...(existingOpportunity.campaigns || []),
+        ...additionalCampaigns,
+      ]
+      existingOpportunity.aprRecord = {
+        ...existingOpportunity.aprRecord,
+        breakdowns: [...existingBreakdowns, ...additionalBreakdowns],
+      }
+    }
+
+    return [...mergedOpportunities.values()]
   }
 
   private describeRequestError(error: unknown): string {
@@ -287,6 +373,58 @@ export class MerklApiService {
       return filteredOpportunities
     } catch (error) {
       console.error('Error fetching ERC20 Log Processor opportunities:', error)
+      return []
+    }
+  }
+
+  async getYearnVaultRewardOpportunities(): Promise<MerklOpportunity[]> {
+    try {
+      const opportunityResults = await Promise.all(
+        YEARN_VAULT_REWARD_OPPORTUNITY_TYPES.map(async (type) => {
+          try {
+            const params = {
+              status: 'LIVE',
+              chainId: config.katanaChainId,
+              type,
+              campaigns: true,
+            }
+
+            return await this.fetchOpportunities(params)
+          } catch (error) {
+            console.error(`Error fetching ${type} opportunities:`, error)
+            return []
+          }
+        }),
+      )
+
+      const filteredOpportunities = this.filterCampaigns(
+        opportunityResults.flat(),
+      )
+      const mergedOpportunities = this.mergeOpportunities(filteredOpportunities)
+
+      for (const opportunity of mergedOpportunities) {
+        const vaultAddress = extractAddressFromIdentifier(
+          opportunity.identifier,
+        )
+        if (!vaultAddress) {
+          continue
+        }
+
+        logVaultAprDebug({
+          stage: 'opportunity_fetch',
+          vaultAddress,
+          poolType: 'yearn',
+          opportunityType: YEARN_VAULT_REWARD_OPPORTUNITY_TYPES.join(','),
+          opportunityIdentifier: opportunity.identifier,
+          opportunitiesTotal: mergedOpportunities.length,
+          campaignsTotal: opportunity.campaigns?.length || 0,
+          reason: 'merkl_opportunity_loaded',
+        })
+      }
+
+      return mergedOpportunities
+    } catch (error) {
+      console.error('Error fetching Yearn vault reward opportunities:', error)
       return []
     }
   }

--- a/src/app/services/externalApis/yearnApi.test.ts
+++ b/src/app/services/externalApis/yearnApi.test.ts
@@ -57,7 +57,7 @@ describe('YearnApiService', () => {
           name: 'vbUSDC yVault',
           symbol: 'yvvbUSDC',
           totalAssets: '1000000',
-          totalDebt: '100',
+          totalDebt: '800000',
           asset: {
             address: '0x00000000000000000000000000000000000000cc',
             name: 'Vault Bridge USDC',
@@ -88,7 +88,7 @@ describe('YearnApiService', () => {
               address: '0x00000000000000000000000000000000000000dd',
               name: 'Morpho Strategy',
               status: 'active',
-              currentDebt: '42',
+              currentDebt: '640000',
               totalGain: '2',
               totalLoss: '1',
               lastReport: '123',
@@ -139,12 +139,12 @@ describe('YearnApiService', () => {
         rewardToken: null,
         underlyingContract: null,
         details: {
-          totalDebt: '42',
+          totalDebt: '640000',
           totalGain: '2',
           totalLoss: '1',
           lastReport: 123,
           performanceFee: 0,
-          debtRatio: 4200,
+          debtRatio: 6400,
         },
       },
     ])

--- a/src/app/services/externalApis/yearnApi.ts
+++ b/src/app/services/externalApis/yearnApi.ts
@@ -134,17 +134,17 @@ const normalizeShareValue = (
 
 const calculateDebtRatio = (
   strategyDebt: unknown,
-  vaultDebt: unknown,
+  vaultTotalAssets: unknown,
 ): number | undefined => {
   try {
     const debt = BigInt(String(strategyDebt ?? '0'))
-    const totalDebt = BigInt(String(vaultDebt ?? '0'))
-    if (debt <= BigInt(0) || totalDebt <= BigInt(0)) {
+    const totalAssets = BigInt(String(vaultTotalAssets ?? '0'))
+    if (debt <= BigInt(0) || totalAssets <= BigInt(0)) {
       return undefined
     }
 
     return Number(
-      (debt * BigInt(10_000) + totalDebt / BigInt(2)) / totalDebt,
+      (debt * BigInt(10_000) + totalAssets / BigInt(2)) / totalAssets,
     )
   } catch {
     return undefined
@@ -203,7 +203,7 @@ const mapKongCompositionToYearnStrategy = (
     lastReport: toNumber(strategy.lastReport),
     performanceFee: toNumber(strategy.performanceFee),
   }
-  const debtRatio = calculateDebtRatio(totalDebt, snapshot.totalDebt)
+  const debtRatio = calculateDebtRatio(totalDebt, snapshot.totalAssets)
   if (debtRatio !== undefined) {
     details.debtRatio = debtRatio
   }


### PR DESCRIPTION
## Summary

Two scoped fixes to vault APR/composition reporting:

- **#46 — Merkl `ERC20_MAPPING` vault rewards:** Katana vault rewards could
  report `0` even when Merkl had live KAT yield, because the service only
  fetched `ERC20LOGPROCESSOR` opportunities. Some vault reward campaigns now
  use `ERC20_MAPPING`. The vault-level fetch now pulls both types, merges and
  deduplicates overlapping opportunities (by identifier, with campaign and APR
  breakdown dedup), and preserves the existing campaign blacklist filtering.
- **#47 — Strategy `debtRatio` against `totalAssets`:** `debtRatio` now divides
  strategy `currentDebt` by `vault.totalAssets` (instead of `totalDebt`), so
  idle vault assets correctly reduce a strategy's reported allocation. Existing
  basis-point scale, rounding, and zero/invalid-denominator handling are
  unchanged.

## Changes

- `merklApi.ts`: new `getYearnVaultRewardOpportunities()` fetching
  `ERC20LOGPROCESSOR` + `ERC20_MAPPING`, with `mergeOpportunities()` dedup.
- `yearnAprCalculator.ts`: vault APR path now uses the combined opportunity list.
- `yearnApi.ts`: `calculateDebtRatio()` now denominates on `totalAssets`.
- Tests added/updated for both behaviors.

## Test plan

- [x] `bun run test:run` — 49 passed
- [x] `bun run lint` — no warnings or errors

## Risk

Low. Both changes are scoped to existing fields. No changes to `apr.forwardAPR`
shape or APY calculation. Merkl APR unit handling (percent ÷ 100) unchanged.

Closes #46
Closes #47
