### PR TITLE
Prepare Katana estimated forward APR contract

### DIFF
--- a/src/app/services/externalApis/yearnApi.test.ts
+++ b/src/app/services/externalApis/yearnApi.test.ts
@@ -122,6 +122,16 @@ describe('YearnApiService', () => {
           weekAgo: 0.99,
           monthAgo: 0.98,
         },
+        forwardAPR: {
+          type: 'katana-estimated-apr',
+          apr: null,
+          apy: null,
+          grossAPR: null,
+          grossAPY: null,
+          netAPR: null,
+          netAPY: null,
+          components: {},
+        },
       },
       tvl: {
         totalAssets: '1000000',
@@ -155,5 +165,109 @@ describe('YearnApiService', () => {
         reason: 'fetched_from_kong',
       }),
     )
+    expect(vaults[0].apr?.forwardAPR).not.toHaveProperty('composite')
+  })
+
+  it('preserves Kong strategy oracle and estimated performance fields', async () => {
+    mocks.fetchGet.mockImplementation((url: string) => {
+      if (
+        url.endsWith(
+          '/snapshot/747474/0x00000000000000000000000000000000000000aa',
+        )
+      ) {
+        return makeOkResponse({
+          chainId: 747474,
+          address: '0x00000000000000000000000000000000000000aa',
+          name: 'vbUSDC yVault',
+          symbol: 'yvvbUSDC',
+          decimals: '6',
+          totalAssets: '1000000',
+          asset: {
+            address: '0x00000000000000000000000000000000000000cc',
+            name: 'Vault Bridge USDC',
+            symbol: 'vbUSDC',
+            decimals: '6',
+          },
+          apy: {
+            net: 0.03,
+            monthlyNet: 0.01,
+            pricePerShare: '1000000',
+          },
+          performance: {
+            oracle: {
+              netAPR: 0.99,
+            },
+            historical: {
+              net: 0.04,
+              monthlyNet: 0.02,
+            },
+          },
+          tvl: {
+            close: 100,
+          },
+          composition: [
+            {
+              address: '0x00000000000000000000000000000000000000dd',
+              name: 'Steer Strategy',
+              status: 'active',
+              currentDebt: '640000',
+              performance: {
+                oracle: {
+                  apr: '0.11',
+                  apy: '0.12',
+                  source: 'kong-oracle',
+                },
+                estimated: {
+                  apr: '0.01',
+                  apy: '0.011',
+                  grossAPR: '0.13',
+                  grossAPY: '0.14',
+                  netAPR: '0.10',
+                  netAPY: '0.105',
+                  components: {
+                    oracleAPY: '0.12',
+                    katRewardsAPR: '0.05',
+                    empty: null,
+                  },
+                },
+              },
+            },
+          ],
+        })
+      }
+
+      throw new Error(`Unexpected fetch URL: ${url}`)
+    })
+
+    const service = new YearnApiService()
+    const vault = await service.getVaultByAddress(
+      '0x00000000000000000000000000000000000000aa',
+      config.katanaChainId,
+    )
+
+    expect(vault?.apr?.netAPR).toBe(0.01)
+    expect(vault?.apr?.netAPR).not.toBe(0.99)
+    expect(vault?.strategies[0]).toMatchObject({
+      oracleAPR: 0.11,
+      oracleAPY: 0.12,
+      oracleSource: 'kong-oracle',
+      estimatedAPR: 0.01,
+      estimatedAPY: 0.011,
+      estimatedGrossAPR: 0.13,
+      estimatedGrossAPY: 0.14,
+      estimatedNetAPR: 0.1,
+      estimatedNetAPY: 0.105,
+      estimatedComponents: {
+        oracleAPY: 0.12,
+        katRewardsAPR: 0.05,
+        empty: null,
+      },
+      strategyRewardsAPR: 0.05,
+      rewardToken: {
+        address: '0x7F1f4b4b29f5058fA32CC7a97141b8D7e5ABDC2d',
+        symbol: 'KAT',
+        decimals: 18,
+      },
+    })
   })
 })

--- a/src/app/services/externalApis/yearnApi.ts
+++ b/src/app/services/externalApis/yearnApi.ts
@@ -30,7 +30,18 @@ type KongVaultCompositionItem = {
   performanceFee?: string | number
   latestReportApr?: number | null
   performance?: {
+    oracle?: {
+      apr?: number | string | null
+      apy?: number | string | null
+      source?: string | null
+    }
     estimated?: {
+      apr?: number | string | null
+      apy?: number | string | null
+      grossAPR?: number | string | null
+      grossAPY?: number | string | null
+      netAPR?: number | string | null
+      netAPY?: number | string | null
       components?: Record<string, number | string | null>
     }
   }
@@ -165,6 +176,21 @@ const toPositiveFiniteNumberOrNull = (value: unknown): number | null => {
   return parsed && parsed > 0 ? parsed : null
 }
 
+const mapNullableNumberRecord = (
+  record?: Record<string, number | string | null>,
+): Record<string, number | null> | undefined => {
+  if (!record) {
+    return undefined
+  }
+
+  return Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [
+      key,
+      toFiniteNumberOrNull(value),
+    ]),
+  )
+}
+
 const isKatanaYearnVault = (vault: KongVaultListItem): boolean =>
   vault.origin === 'yearn' && vault.inclusion?.isKatana === true
 
@@ -193,8 +219,11 @@ const mapKongCompositionToYearnStrategy = (
   }
 
   const totalDebt = toStringValue(strategy.currentDebt ?? strategy.totalDebt)
+  const oracle = strategy.performance?.oracle
+  const estimated = strategy.performance?.estimated
+  const estimatedComponents = mapNullableNumberRecord(estimated?.components)
   const estimatedKatRewardsAPR = toFiniteNumberOrNull(
-    strategy.performance?.estimated?.components?.katRewardsAPR,
+    estimatedComponents?.katRewardsAPR,
   )
   const details: YearnStrategyDetails = {
     totalDebt,
@@ -213,6 +242,24 @@ const mapKongCompositionToYearnStrategy = (
     name: strategy.name || 'Unknown',
     status: totalDebt === '0' ? 'unallocated' : strategy.status,
     netAPR: toPositiveFiniteNumberOrNull(strategy.latestReportApr),
+    ...(oracle
+      ? {
+          oracleAPR: toFiniteNumberOrNull(oracle.apr),
+          oracleAPY: toFiniteNumberOrNull(oracle.apy),
+          oracleSource: oracle.source ?? null,
+        }
+      : {}),
+    ...(estimated
+      ? {
+          estimatedAPR: toFiniteNumberOrNull(estimated.apr),
+          estimatedAPY: toFiniteNumberOrNull(estimated.apy),
+          estimatedGrossAPR: toFiniteNumberOrNull(estimated.grossAPR),
+          estimatedGrossAPY: toFiniteNumberOrNull(estimated.grossAPY),
+          estimatedNetAPR: toFiniteNumberOrNull(estimated.netAPR),
+          estimatedNetAPY: toFiniteNumberOrNull(estimated.netAPY),
+          ...(estimatedComponents ? { estimatedComponents } : {}),
+        }
+      : {}),
     strategyRewardsAPR: estimatedKatRewardsAPR,
     rewardToken:
       estimatedKatRewardsAPR !== null && estimatedKatRewardsAPR > 0
@@ -264,16 +311,14 @@ const mapKongAprToYearnApr = (snapshot: KongVaultSnapshot): YearnVaultAPY => {
       ),
     },
     forwardAPR: {
-      type: '',
+      type: 'katana-estimated-apr',
+      apr: null,
+      apy: null,
+      grossAPR: null,
+      grossAPY: null,
       netAPR: null,
-      composite: {
-        boost: null,
-        poolAPY: null,
-        boostedAPR: null,
-        baseAPR: null,
-        cvxAPR: null,
-        rewardsAPR: null,
-      },
+      netAPY: null,
+      components: {},
     },
   }
 }

--- a/src/app/types/yearn.ts
+++ b/src/app/types/yearn.ts
@@ -19,6 +19,16 @@ export interface YearnStrategy {
   name: string
   status?: string
   netAPR?: number | null
+  oracleAPR?: number | null
+  oracleAPY?: number | null
+  oracleSource?: string | null
+  estimatedAPR?: number | null
+  estimatedAPY?: number | null
+  estimatedGrossAPR?: number | null
+  estimatedGrossAPY?: number | null
+  estimatedNetAPR?: number | null
+  estimatedNetAPY?: number | null
+  estimatedComponents?: Record<string, number | null>
   strategyRewardsAPR?: number | null
   rewardToken?: YearnRewardToken | null
   underlyingContract?: string | null
@@ -62,16 +72,14 @@ export interface YearnVaultAPY {
   pricePerShare?: YearnVaultPricePerShare
   extra?: YearnVaultExtra
   forwardAPR?: {
-    type: string
-    netAPR: number | null
-    composite: {
-      boost: number | null
-      poolAPY: number | null
-      boostedAPR: number | null
-      baseAPR: number | null
-      cvxAPR: number | null
-      rewardsAPR: number | null
-    }
+    type: 'katana-estimated-apr'
+    apr?: number | null
+    apy?: number | null
+    grossAPR?: number | null
+    grossAPY?: number | null
+    netAPR?: number | null
+    netAPY?: number | null
+    components: Record<string, number | null>
   }
 }
 


### PR DESCRIPTION
## Summary

Implements the interface and API response contract preparation work from #49.

- Adds strategy oracle and estimated annual percentage rate / annual percentage yield fields to the Yearn response types.
- Replaces the old Curve-specific `forwardAPR.composite` response shape with the new `katana-estimated-apr` response shape.
- Preserves Kong strategy `performance.oracle` and `performance.estimated` fields when Kong sends them.
- Keeps top-level `apr.netAPR` as historical price-per-share performance, separate from the new forward estimated net fields.
- Adds response-shape tests, including coverage that `forwardAPR.composite` is no longer returned.

## Validation

- `bun run test:run`
- `bun run build`

## Notes

This pull request intentionally does not add Morpho forward calculations or webhook forward rows. Those are handled in the stacked calculation pull request.
