### PR TITLE
Add Morpho compounder APR replacement

### DIFF
--- a/src/app/config/index.ts
+++ b/src/app/config/index.ts
@@ -24,6 +24,8 @@ export const config = {
   yDaemonApiUrl: process.env.YDAEMON_BASE_URI || 'https://ydaemon.yearn.fi',
   merklApiUrl: process.env.MERKL_BASE_URI || 'https://api.merkl.xyz',
   merklApiKey: process.env.MERKL_API_KEY?.trim() || undefined,
+  morphoApiUri:
+    process.env.MORPHO_API_URI || 'https://api.morpho.org/graphql',
   coingeckoApiUrl:
     process.env.COINGECKO_BASE_URI || 'https://api.coingecko.com/api/v3',
   coingeckoApiKey: process.env.COINGECKO_API_KEY,

--- a/src/app/services/aprCalcs/morphoUnderlyingAprCalculator.test.ts
+++ b/src/app/services/aprCalcs/morphoUnderlyingAprCalculator.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { YearnVault } from '../../types'
+
+const mocks = vi.hoisted(() => ({
+  getActiveMorphoCompounderStrategies: vi.fn(),
+  getMorphoVaultsFromStrategies: vi.fn(),
+  getVaultAprEstimates: vi.fn(),
+}))
+
+vi.mock('../externalApis/yearnApi', () => ({
+  YearnApiService: vi.fn().mockImplementation(() => ({
+    getActiveMorphoCompounderStrategies:
+      mocks.getActiveMorphoCompounderStrategies,
+  })),
+}))
+
+vi.mock('../contractReader', () => ({
+  ContractReaderService: vi.fn().mockImplementation(() => ({
+    getMorphoVaultsFromStrategies: mocks.getMorphoVaultsFromStrategies,
+  })),
+}))
+
+vi.mock('../externalApis/morphoApi', () => ({
+  MorphoApiService: vi.fn().mockImplementation(() => ({
+    getVaultAprEstimates: mocks.getVaultAprEstimates,
+  })),
+}))
+
+import { MorphoUnderlyingAprCalculator } from './morphoUnderlyingAprCalculator'
+
+const VAULT_ADDRESS = '0x00000000000000000000000000000000000000aa'
+const COMPOUNDER_ADDRESS = '0x00000000000000000000000000000000000000bb'
+const LENDER_BORROWER_ADDRESS = '0x00000000000000000000000000000000000000cc'
+const STEER_ADDRESS = '0x00000000000000000000000000000000000000dd'
+const MORPHO_VAULT_ADDRESS = '0x00000000000000000000000000000000000000ee'
+
+const makeVault = (): YearnVault => ({
+  address: VAULT_ADDRESS,
+  symbol: 'yvvbUSDC',
+  name: 'USDC yVault',
+  chainID: 747474,
+  apr: {
+    netAPR: 0.02,
+  },
+  tvl: {
+    totalAssets: '100',
+    tvl: 100,
+    price: 1,
+  },
+  strategies: [
+    {
+      address: COMPOUNDER_ADDRESS,
+      name: 'Morpho Yearn USDC Compounder',
+      netAPR: 0.01,
+      details: {
+        totalDebt: '50',
+        totalGain: '0',
+        totalLoss: '0',
+        lastReport: 0,
+        debtRatio: 5000,
+      },
+    },
+    {
+      address: LENDER_BORROWER_ADDRESS,
+      name: 'Morpho USDC Lender Borrower',
+      netAPR: 0.20,
+      details: {
+        totalDebt: '25',
+        totalGain: '0',
+        totalLoss: '0',
+        lastReport: 0,
+        debtRatio: 2500,
+      },
+    },
+    {
+      address: STEER_ADDRESS,
+      name: 'Steer USDC Strategy',
+      netAPR: 0.30,
+      details: {
+        totalDebt: '25',
+        totalGain: '0',
+        totalLoss: '0',
+        lastReport: 0,
+        debtRatio: 2500,
+      },
+    },
+  ],
+})
+
+describe('MorphoUnderlyingAprCalculator', () => {
+  beforeEach(() => {
+    mocks.getActiveMorphoCompounderStrategies.mockReset()
+    mocks.getMorphoVaultsFromStrategies.mockReset()
+    mocks.getVaultAprEstimates.mockReset()
+  })
+
+  it('uses dynamic vault mapping for selected active compounders only', async () => {
+    const vault = makeVault()
+    mocks.getActiveMorphoCompounderStrategies.mockReturnValue([
+      COMPOUNDER_ADDRESS,
+    ])
+    mocks.getMorphoVaultsFromStrategies.mockResolvedValue({
+      [COMPOUNDER_ADDRESS]: MORPHO_VAULT_ADDRESS,
+    })
+    mocks.getVaultAprEstimates.mockResolvedValue({
+      [MORPHO_VAULT_ADDRESS.toLowerCase()]: {
+        baseAPY: 0.052,
+        rewardsAPR: 0.01,
+      },
+    })
+
+    const calculator = new MorphoUnderlyingAprCalculator()
+    const results = await calculator.calculateVaultAPRs([vault])
+
+    expect(mocks.getActiveMorphoCompounderStrategies).toHaveBeenCalledWith(
+      vault,
+    )
+    expect(mocks.getMorphoVaultsFromStrategies).toHaveBeenCalledWith([
+      COMPOUNDER_ADDRESS,
+    ])
+    expect(mocks.getVaultAprEstimates).toHaveBeenCalledWith([
+      MORPHO_VAULT_ADDRESS,
+    ])
+    expect(results[VAULT_ADDRESS]).toEqual([
+      {
+        strategyAddress: COMPOUNDER_ADDRESS,
+        morphoVaultAddress: MORPHO_VAULT_ADDRESS,
+        replacementAPR: 52 * ((1 + 0.052) ** (1 / 52) - 1) + 0.01,
+        usedMorphoApi: true,
+      },
+    ])
+  })
+
+  it('falls back to the existing strategy APR when an estimate is missing', async () => {
+    const vault = makeVault()
+    mocks.getActiveMorphoCompounderStrategies.mockReturnValue([
+      COMPOUNDER_ADDRESS,
+    ])
+    mocks.getMorphoVaultsFromStrategies.mockResolvedValue({
+      [COMPOUNDER_ADDRESS]: MORPHO_VAULT_ADDRESS,
+    })
+    mocks.getVaultAprEstimates.mockResolvedValue({})
+
+    const calculator = new MorphoUnderlyingAprCalculator()
+    const results = await calculator.calculateVaultAPRs([vault])
+
+    expect(results[VAULT_ADDRESS]).toEqual([
+      {
+        strategyAddress: COMPOUNDER_ADDRESS,
+        morphoVaultAddress: MORPHO_VAULT_ADDRESS,
+        replacementAPR: 0.01,
+        usedMorphoApi: false,
+      },
+    ])
+  })
+})

--- a/src/app/services/aprCalcs/morphoUnderlyingAprCalculator.ts
+++ b/src/app/services/aprCalcs/morphoUnderlyingAprCalculator.ts
@@ -1,0 +1,142 @@
+import _ from 'lodash'
+import type { YearnVault, YearnStrategy } from '../../types'
+import { ContractReaderService } from '../contractReader'
+import { MorphoApiService, type MorphoVaultAprEstimate } from '../externalApis/morphoApi'
+import { YearnApiService } from '../externalApis/yearnApi'
+
+export interface MorphoUnderlyingAprResult {
+  strategyAddress: string
+  morphoVaultAddress: string | null
+  replacementAPR: number
+  usedMorphoApi: boolean
+}
+
+export class MorphoUnderlyingAprCalculator {
+  private yearnApi: YearnApiService
+  private contractReader: ContractReaderService
+  private morphoApi: MorphoApiService
+
+  constructor() {
+    this.yearnApi = new YearnApiService()
+    this.contractReader = new ContractReaderService()
+    this.morphoApi = new MorphoApiService()
+  }
+
+  async calculateVaultAPRs(
+    vaults: YearnVault[],
+  ): Promise<Record<string, MorphoUnderlyingAprResult[]>> {
+    const vaultStrategyPairs = vaults
+      .map((vault) => ({
+        vault,
+        strategyAddresses:
+          this.yearnApi.getActiveMorphoCompounderStrategies(vault),
+      }))
+      .filter(({ strategyAddresses }) => strategyAddresses.length > 0)
+
+    const allStrategyAddresses = vaultStrategyPairs.flatMap(
+      ({ strategyAddresses }) => strategyAddresses,
+    )
+
+    if (allStrategyAddresses.length === 0) {
+      return {}
+    }
+
+    const strategyToMorphoVault = await this.getStrategyToMorphoVault(
+      allStrategyAddresses,
+    )
+    const morphoVaultAddresses = _.uniq(
+      Object.values(strategyToMorphoVault).filter(Boolean),
+    )
+    const morphoVaultEstimates = await this.getMorphoVaultEstimates(
+      morphoVaultAddresses,
+    )
+
+    const resultEntries = vaultStrategyPairs
+      .map(({ vault, strategyAddresses }) => {
+        const strategiesByAddress = new Map(
+          vault.strategies.map((strategy) => [
+            strategy.address.toLowerCase(),
+            strategy,
+          ]),
+        )
+
+        const results = strategyAddresses
+          .map((strategyAddress) => {
+            const strategy = strategiesByAddress.get(
+              strategyAddress.toLowerCase(),
+            )
+
+            if (!strategy) {
+              return null
+            }
+
+            const morphoVaultAddress =
+              strategyToMorphoVault[strategyAddress.toLowerCase()] || null
+            const estimate = morphoVaultAddress
+              ? morphoVaultEstimates[morphoVaultAddress.toLowerCase()]
+              : undefined
+
+            return {
+              strategyAddress,
+              morphoVaultAddress,
+              replacementAPR: estimate
+                ? this.calculateReplacementAPR(estimate)
+                : this.getFallbackStrategyAPR(strategy),
+              usedMorphoApi: Boolean(estimate),
+            }
+          })
+          .filter(
+            (result): result is MorphoUnderlyingAprResult => result !== null,
+          )
+
+        return results.length > 0 ? [vault.address, results] : null
+      })
+      .filter(
+        (entry): entry is [string, MorphoUnderlyingAprResult[]] =>
+          entry !== null,
+      )
+
+    return _.fromPairs(resultEntries)
+  }
+
+  private async getStrategyToMorphoVault(
+    strategyAddresses: string[],
+  ): Promise<Record<string, string>> {
+    const strategyToMorphoVault =
+      await this.contractReader.getMorphoVaultsFromStrategies(strategyAddresses)
+
+    return _.chain(strategyToMorphoVault)
+      .toPairs()
+      .map(([strategyAddress, morphoVaultAddress]) => [
+        strategyAddress.toLowerCase(),
+        morphoVaultAddress,
+      ])
+      .fromPairs()
+      .value()
+  }
+
+  private async getMorphoVaultEstimates(
+    morphoVaultAddresses: string[],
+  ): Promise<Record<string, MorphoVaultAprEstimate>> {
+    if (morphoVaultAddresses.length === 0) {
+      return {}
+    }
+
+    return this.morphoApi.getVaultAprEstimates(morphoVaultAddresses)
+  }
+
+  private calculateReplacementAPR(
+    estimate: MorphoVaultAprEstimate,
+  ): number {
+    return this.convertApyToWeeklyApr(estimate.baseAPY) + estimate.rewardsAPR
+  }
+
+  private convertApyToWeeklyApr(apy: number): number {
+    return 52 * ((1 + apy) ** (1 / 52) - 1)
+  }
+
+  private getFallbackStrategyAPR(strategy: YearnStrategy): number {
+    const parsed = Number(strategy.netAPR)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+  }
+}

--- a/src/app/services/dataCache.test.ts
+++ b/src/app/services/dataCache.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   mockGetVaults: vi.fn(),
   mockCalculateYearnVaultAPRs: vi.fn(),
   mockCalculateMorphoVaultAPRs: vi.fn(),
+  mockCalculateMorphoUnderlyingVaultAPRs: vi.fn(),
   mockCalculateSushiVaultAPRs: vi.fn(),
   logVaultAprDebug: vi.fn(),
 }))
@@ -24,6 +25,12 @@ vi.mock('./aprCalcs/yearnAprCalculator', () => ({
 vi.mock('./aprCalcs/morphoAprCalculator', () => ({
   MorphoAprCalculator: vi.fn().mockImplementation(() => ({
     calculateVaultAPRs: mocks.mockCalculateMorphoVaultAPRs,
+  })),
+}))
+
+vi.mock('./aprCalcs/morphoUnderlyingAprCalculator', () => ({
+  MorphoUnderlyingAprCalculator: vi.fn().mockImplementation(() => ({
+    calculateVaultAPRs: mocks.mockCalculateMorphoUnderlyingVaultAPRs,
   })),
 }))
 
@@ -58,10 +65,12 @@ describe('DataCacheService.generateVaultAPRData', () => {
     mocks.mockGetVaults.mockReset()
     mocks.mockCalculateYearnVaultAPRs.mockReset()
     mocks.mockCalculateMorphoVaultAPRs.mockReset()
+    mocks.mockCalculateMorphoUnderlyingVaultAPRs.mockReset()
     mocks.mockCalculateSushiVaultAPRs.mockReset()
     mocks.logVaultAprDebug.mockReset()
     mocks.mockCalculateYearnVaultAPRs.mockResolvedValue({})
     mocks.mockCalculateMorphoVaultAPRs.mockResolvedValue({})
+    mocks.mockCalculateMorphoUnderlyingVaultAPRs.mockResolvedValue({})
     mocks.mockCalculateSushiVaultAPRs.mockResolvedValue({})
   })
 
@@ -298,5 +307,144 @@ describe('DataCacheService.generateVaultAPRData', () => {
     expect(data[vault.address].strategies[0].underlyingContract).toBeNull()
     expect(data[vault.address].apr?.extra?.katanaAppRewardsAPR).toBe(0)
     expect(data[vault.address].apr?.extra?.katanaRewardsAPR).toBe(0)
+  })
+
+  it('weights Morpho replacement APR with unchanged strategy sources and idle assets', async () => {
+    const morphoStrategyAddress =
+      '0x00000000000000000000000000000000000000f1'
+    const steerStrategyAddress =
+      '0x00000000000000000000000000000000000000f2'
+    const idleStrategyAddress =
+      '0x00000000000000000000000000000000000000f3'
+    const vault = makeVault({
+      apr: {
+        netAPR: 0.0123,
+        forwardAPR: {
+          type: '',
+          netAPR: null,
+          composite: {
+            boost: null,
+            poolAPY: null,
+            boostedAPR: null,
+            baseAPR: null,
+            cvxAPR: null,
+            rewardsAPR: null,
+          },
+        },
+      },
+      tvl: {
+        totalAssets: '100',
+        tvl: 100,
+        price: 1,
+      },
+      strategies: [
+        {
+          address: morphoStrategyAddress,
+          name: 'Morpho Yearn USDC Compounder',
+          status: 'active',
+          netAPR: 0.01,
+          details: {
+            totalDebt: '50',
+            totalGain: '0',
+            totalLoss: '0',
+            lastReport: 0,
+            debtRatio: 5000,
+          },
+        },
+        {
+          address: steerStrategyAddress,
+          name: 'Steer USDC Strategy',
+          status: 'active',
+          netAPR: 0.04,
+          details: {
+            totalDebt: '25',
+            totalGain: '0',
+            totalLoss: '0',
+            lastReport: 0,
+            debtRatio: 2500,
+          },
+        },
+        {
+          address: idleStrategyAddress,
+          name: 'Idle Slot',
+          status: 'unallocated',
+          netAPR: 0.50,
+          details: {
+            totalDebt: '0',
+            totalGain: '0',
+            totalLoss: '0',
+            lastReport: 0,
+          },
+        },
+      ],
+    })
+    mocks.mockGetVaults.mockResolvedValue([vault])
+    mocks.mockCalculateMorphoUnderlyingVaultAPRs.mockResolvedValue({
+      [vault.address]: [
+        {
+          strategyAddress: morphoStrategyAddress,
+          morphoVaultAddress:
+            '0x00000000000000000000000000000000000000a1',
+          replacementAPR: 0.10,
+          usedMorphoApi: true,
+        },
+      ],
+    })
+
+    const service = new DataCacheService()
+    const data = await service.generateVaultAPRData()
+
+    expect(data[vault.address].apr?.netAPR).toBe(0.0123)
+    expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(
+      0.10 * 0.5 + 0.04 * 0.25,
+    )
+  })
+
+  it('uses current strategy APR in forward APR when Morpho estimates are missing', async () => {
+    const morphoStrategyAddress =
+      '0x00000000000000000000000000000000000000f4'
+    const vault = makeVault({
+      apr: {
+        netAPR: 0.02,
+      },
+      tvl: {
+        totalAssets: '100',
+        tvl: 100,
+        price: 1,
+      },
+      strategies: [
+        {
+          address: morphoStrategyAddress,
+          name: 'Morpho Yearn USDC Compounder',
+          status: 'active',
+          netAPR: 0.03,
+          details: {
+            totalDebt: '50',
+            totalGain: '0',
+            totalLoss: '0',
+            lastReport: 0,
+            debtRatio: 5000,
+          },
+        },
+      ],
+    })
+    mocks.mockGetVaults.mockResolvedValue([vault])
+    mocks.mockCalculateMorphoUnderlyingVaultAPRs.mockResolvedValue({
+      [vault.address]: [
+        {
+          strategyAddress: morphoStrategyAddress,
+          morphoVaultAddress:
+            '0x00000000000000000000000000000000000000a2',
+          replacementAPR: 0.03,
+          usedMorphoApi: false,
+        },
+      ],
+    })
+
+    const service = new DataCacheService()
+    const data = await service.generateVaultAPRData()
+
+    expect(data[vault.address].apr?.netAPR).toBe(0.02)
+    expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(0.015)
   })
 })

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -334,7 +334,7 @@ export class DataCacheService {
   }
 
   private getCurrentStrategyAPR(strategy: YearnStrategy): number {
-    const parsed = this.toFiniteNumber(strategy.netAPR)
+    const parsed = this.toFiniteNumber(strategy.netAPR ?? undefined)
     return parsed > 0 ? parsed : 0
   }
 

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -1,8 +1,12 @@
 import _ from 'lodash'
 import { config } from '../config/index'
-import type { YearnVault } from '../types/index'
+import type { YearnStrategy, YearnVault, YearnVaultAPY } from '../types/index'
 import { YearnApiService } from './externalApis/yearnApi'
 import { MorphoAprCalculator } from './aprCalcs/morphoAprCalculator'
+import {
+  MorphoUnderlyingAprCalculator,
+  type MorphoUnderlyingAprResult,
+} from './aprCalcs/morphoUnderlyingAprCalculator'
 import { SushiAprCalculator } from './aprCalcs/sushiAprCalculator'
 import { YearnAprCalculator } from './aprCalcs/yearnAprCalculator'
 import { logVaultAprDebug } from './aprCalcs/debugLogger'
@@ -36,12 +40,14 @@ export class DataCacheService {
   private yearnApi: YearnApiService
   private yearnAprCalculator: YearnAprCalculator
   private morphoAprCalculator: MorphoAprCalculator
+  private morphoUnderlyingAprCalculator: MorphoUnderlyingAprCalculator
   private sushiAprCalculator: SushiAprCalculator
 
   constructor() {
     this.yearnApi = new YearnApiService()
     this.yearnAprCalculator = new YearnAprCalculator()
     this.morphoAprCalculator = new MorphoAprCalculator()
+    this.morphoUnderlyingAprCalculator = new MorphoUnderlyingAprCalculator()
     this.sushiAprCalculator = new SushiAprCalculator()
   }
 
@@ -62,10 +68,12 @@ export class DataCacheService {
     const [
       yearnAPRs,
       morphoAPRs,
+      morphoUnderlyingAPRs,
       sushiAPRs,
     ] = await Promise.all([
       this.yearnAprCalculator.calculateVaultAPRs(vaults),
       this.morphoAprCalculator.calculateVaultAPRs(vaults),
+      this.morphoUnderlyingAprCalculator.calculateVaultAPRs(vaults),
       this.sushiAprCalculator.calculateVaultAPRs(vaults),
     ])
 
@@ -81,8 +89,13 @@ export class DataCacheService {
             .flattenDeep()
             .compact()
             .value()
+          const morphoUnderlyingResults =
+            morphoUnderlyingAPRs[vault.address] || []
 
-          if (allResults.length === 0) {
+          if (
+            allResults.length === 0 &&
+            morphoUnderlyingResults.length === 0
+          ) {
             logVaultAprDebug({
               stage: 'fallback',
               vaultAddress: vault.address,
@@ -112,7 +125,11 @@ export class DataCacheService {
 
           return [
             vault.address,
-            this.aggregateVaultResults(vault, allResults),
+            this.aggregateVaultResults(
+              vault,
+              allResults,
+              morphoUnderlyingResults,
+            ),
           ]
         } catch (error) {
           console.error(`Error processing vault ${vault.address}:`, error)
@@ -155,6 +172,7 @@ export class DataCacheService {
   private aggregateVaultResults(
     vault: YearnVault,
     results: VaultRewardCalculatorResult[],
+    morphoUnderlyingResults: MorphoUnderlyingAprResult[] = [],
   ): YearnVault {
     const strategyResults = results.filter(
       (result): result is RewardCalculatorResult => 'strategyAddress' in result,
@@ -214,9 +232,14 @@ export class DataCacheService {
     const vaultKatanaBonusAPY = 0
 
     const katanaNativeYield = vault.apr?.netAPR || 0
+    const forwardAPR = this.buildForwardAPR(
+      vault,
+      morphoUnderlyingResults,
+    )
 
     const apr = {
       ...vault.apr,
+      ...(forwardAPR ? { forwardAPR } : {}),
       extra: {
         ...(vault.apr?.extra || {}),
         stakingRewardsAPR: null,
@@ -242,6 +265,77 @@ export class DataCacheService {
     }
 
     return newVault
+  }
+
+  private buildForwardAPR(
+    vault: YearnVault,
+    morphoUnderlyingResults: MorphoUnderlyingAprResult[],
+  ): YearnVaultAPY['forwardAPR'] | undefined {
+    if (morphoUnderlyingResults.length === 0) {
+      return vault.apr?.forwardAPR
+    }
+
+    const replacementAprByStrategy = new Map(
+      morphoUnderlyingResults.map((result) => [
+        result.strategyAddress.toLowerCase(),
+        result.replacementAPR,
+      ]),
+    )
+
+    const netAPR = (vault.strategies || []).reduce((sum, strategy) => {
+      const debtShare = this.getStrategyDebtShare(strategy, vault)
+      if (debtShare <= 0) {
+        return sum
+      }
+
+      const replacementAPR = replacementAprByStrategy.get(
+        strategy.address.toLowerCase(),
+      )
+      const strategyAPR =
+        replacementAPR ?? this.getCurrentStrategyAPR(strategy)
+
+      return sum + debtShare * strategyAPR
+    }, 0)
+
+    return {
+      type: vault.apr?.forwardAPR?.type || '',
+      netAPR,
+      composite: vault.apr?.forwardAPR?.composite || {
+        boost: null,
+        poolAPY: null,
+        boostedAPR: null,
+        baseAPR: null,
+        cvxAPR: null,
+        rewardsAPR: null,
+      },
+    }
+  }
+
+  private getStrategyDebtShare(
+    strategy: YearnStrategy,
+    vault: YearnVault,
+  ): number {
+    const debtRatio = this.toFiniteNumber(strategy.details?.debtRatio)
+    if (debtRatio > 0) {
+      return debtRatio / 10_000
+    }
+
+    try {
+      const strategyDebt = BigInt(String(strategy.details?.totalDebt ?? '0'))
+      const vaultTotalAssets = BigInt(String(vault.tvl?.totalAssets ?? '0'))
+      if (strategyDebt <= BigInt(0) || vaultTotalAssets <= BigInt(0)) {
+        return 0
+      }
+
+      return Number(strategyDebt) / Number(vaultTotalAssets)
+    } catch {
+      return 0
+    }
+  }
+
+  private getCurrentStrategyAPR(strategy: YearnStrategy): number {
+    const parsed = this.toFiniteNumber(strategy.netAPR)
+    return parsed > 0 ? parsed : 0
   }
 
   private buildStrategyRewardsByAddress(

--- a/src/app/services/externalApis/morphoApi.test.ts
+++ b/src/app/services/externalApis/morphoApi.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  fetchPost: vi.fn(),
+}))
+
+vi.stubGlobal('fetch', mocks.fetchPost)
+
+import { MorphoApiService } from './morphoApi'
+
+const KAT_ADDRESS = '0x7F1f4b4b29f5058fA32CC7a97141b8D7e5ABDC2d'
+const WRAPPED_KAT_ADDRESS = '0x3ba1fbC4c3aEA775d335b31fb53778f46FD3a330'
+const MORPHO_ADDRESS = '0x9994e35db50125e0df82e4c2dde62496ce330999'
+
+const makeOkResponse = (data: unknown) =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(data),
+  })
+
+describe('MorphoApiService', () => {
+  beforeEach(() => {
+    mocks.fetchPost.mockReset()
+  })
+
+  it('normalizes V1 vault base APY and non-KAT rewards', async () => {
+    const address = '0xE4248e2105508FcBad3fe95691551d1AF14015f7'
+    mocks.fetchPost.mockImplementationOnce(() =>
+      makeOkResponse({
+        data: {
+          vaults: {
+            items: [
+              {
+                address,
+                state: {
+                  apy: '0.05',
+                  allRewards: [
+                    {
+                      supplyApr: '0.01',
+                      asset: {
+                        address: MORPHO_ADDRESS,
+                        symbol: 'MORPHO',
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          vaultV2s: {
+            items: [],
+          },
+        },
+      }),
+    )
+
+    const service = new MorphoApiService('https://morpho.test/graphql')
+    const estimates = await service.getVaultAprEstimates([address])
+
+    expect(estimates[address.toLowerCase()]).toEqual({
+      baseAPY: 0.05,
+      rewardsAPR: 0.01,
+    })
+  })
+
+  it('normalizes V2 vault base APY and rewards', async () => {
+    const address = '0x8ED68f91AfbE5871dCE31ae007a936ebE8511d47'
+    mocks.fetchPost.mockImplementationOnce(() =>
+      makeOkResponse({
+        data: {
+          vaults: {
+            items: [],
+          },
+          vaultV2s: {
+            items: [
+              {
+                address,
+                avgNetApyExcludingRewards: 0.04,
+                rewards: [
+                  {
+                    supplyApr: 0.006,
+                    asset: {
+                      address: MORPHO_ADDRESS,
+                      symbol: 'MORPHO',
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      }),
+    )
+
+    const service = new MorphoApiService('https://morpho.test/graphql')
+    const estimates = await service.getVaultAprEstimates([address])
+
+    expect(estimates[address.toLowerCase()]).toEqual({
+      baseAPY: 0.04,
+      rewardsAPR: 0.006,
+    })
+  })
+
+  it('excludes KAT rewards and includes MORPHO rewards', async () => {
+    const address = '0xCE2b8e464Fc7b5E58710C24b7e5EBFB6027f29D7'
+    mocks.fetchPost.mockImplementationOnce(() =>
+      makeOkResponse({
+        data: {
+          vaults: {
+            items: [
+              {
+                address,
+                state: {
+                  apy: 0.03,
+                  allRewards: [
+                    {
+                      supplyApr: 0.02,
+                      asset: {
+                        address: MORPHO_ADDRESS,
+                        symbol: 'MORPHO',
+                      },
+                    },
+                    {
+                      supplyApr: 0.50,
+                      asset: {
+                        address: KAT_ADDRESS,
+                        symbol: 'KAT',
+                      },
+                    },
+                    {
+                      supplyApr: 0.25,
+                      asset: {
+                        address: WRAPPED_KAT_ADDRESS,
+                        symbol: 'KAT',
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          vaultV2s: {
+            items: [],
+          },
+        },
+      }),
+    )
+
+    const service = new MorphoApiService('https://morpho.test/graphql')
+    const estimates = await service.getVaultAprEstimates([address])
+
+    expect(estimates[address.toLowerCase()]).toEqual({
+      baseAPY: 0.03,
+      rewardsAPR: 0.02,
+    })
+  })
+
+  it('returns partial data when GraphQL errors include data', async () => {
+    const address = '0xA2d38c8A3D810EBcF4C2075821c5eC8F976bb692'
+    mocks.fetchPost.mockImplementationOnce(() =>
+      makeOkResponse({
+        errors: [{ message: 'partial failure' }],
+        data: {
+          vaults: {
+            items: [
+              {
+                address,
+                state: {
+                  apy: 0.01,
+                  allRewards: [],
+                },
+              },
+            ],
+          },
+          vaultV2s: {
+            items: [],
+          },
+        },
+      }),
+    )
+
+    const service = new MorphoApiService('https://morpho.test/graphql')
+    const estimates = await service.getVaultAprEstimates([address])
+
+    expect(estimates[address.toLowerCase()]).toEqual({
+      baseAPY: 0.01,
+      rewardsAPR: 0,
+    })
+  })
+
+  it('returns an empty map on API errors', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    mocks.fetchPost.mockRejectedValueOnce(new Error('network failed'))
+
+    const service = new MorphoApiService('https://morpho.test/graphql')
+    const estimates = await service.getVaultAprEstimates([
+      '0xbeeff2d5d126d4809195EeA02b605423917bb6c6',
+    ])
+
+    expect(estimates).toEqual({})
+    expect(consoleError).toHaveBeenCalledWith(
+      'Error fetching Morpho vault APRs:',
+      expect.any(Error),
+    )
+
+    consoleError.mockRestore()
+  })
+})

--- a/src/app/services/externalApis/morphoApi.ts
+++ b/src/app/services/externalApis/morphoApi.ts
@@ -1,0 +1,177 @@
+import { config } from '../../config'
+import { isKatanaRewardTokenAddress } from '../katanaRewardTokens'
+
+export interface MorphoVaultAprEstimate {
+  baseAPY: number
+  rewardsAPR: number
+}
+
+type MorphoReward = {
+  supplyApr?: number | string | null
+  asset?: {
+    address?: string | null
+    symbol?: string | null
+  } | null
+}
+
+type MorphoVaultV1 = {
+  address?: string | null
+  state?: {
+    apy?: number | string | null
+    allRewards?: MorphoReward[] | null
+  } | null
+}
+
+type MorphoVaultV2 = {
+  address?: string | null
+  avgNetApyExcludingRewards?: number | string | null
+  rewards?: MorphoReward[] | null
+}
+
+type MorphoGraphQlResponse = {
+  data?: {
+    vaults?: {
+      items?: MorphoVaultV1[] | null
+    } | null
+    vaultV2s?: {
+      items?: MorphoVaultV2[] | null
+    } | null
+  } | null
+  errors?: unknown[]
+}
+
+const MORPHO_VAULT_APR_QUERY = `
+  query KatanaMorphoVaultAprs($chainIds: [Int!], $addresses: [String!], $first: Int!) {
+    vaults(first: $first, where: { chainId_in: $chainIds, address_in: $addresses }) {
+      items {
+        address
+        state {
+          apy
+          allRewards {
+            supplyApr
+            asset {
+              address
+              symbol
+            }
+          }
+        }
+      }
+    }
+    vaultV2s(first: $first, where: { chainId_in: $chainIds, address_in: $addresses }) {
+      items {
+        address
+        avgNetApyExcludingRewards
+        rewards {
+          supplyApr
+          asset {
+            address
+            symbol
+          }
+        }
+      }
+    }
+  }
+`
+
+const toFiniteNumber = (value: unknown): number => {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+const sumNonKatRewardsAPR = (rewards?: MorphoReward[] | null): number =>
+  (rewards || []).reduce((sum, reward) => {
+    if (isKatanaRewardTokenAddress(reward.asset?.address || undefined)) {
+      return sum
+    }
+
+    return sum + toFiniteNumber(reward.supplyApr)
+  }, 0)
+
+export class MorphoApiService {
+  private apiUri: string
+
+  constructor(apiUri: string = config.morphoApiUri) {
+    this.apiUri = apiUri
+  }
+
+  async getVaultAprEstimates(
+    addresses: string[],
+    chainId: number = config.katanaChainId,
+  ): Promise<Record<string, MorphoVaultAprEstimate>> {
+    const normalizedAddresses = Array.from(
+      new Set(
+        addresses
+          .map((address) => address.toLowerCase())
+          .filter((address) => address.length > 0),
+      ),
+    )
+
+    if (normalizedAddresses.length === 0) {
+      return {}
+    }
+
+    try {
+      const response = await fetch(this.apiUri, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: MORPHO_VAULT_APR_QUERY,
+          variables: {
+            chainIds: [chainId],
+            addresses: normalizedAddresses,
+            first: normalizedAddresses.length,
+          },
+        }),
+      })
+
+      if (!response.ok) {
+        throw Object.assign(new Error('HTTP error fetching Morpho vault APRs'), {
+          status: response.status,
+        })
+      }
+
+      const payload = (await response.json()) as MorphoGraphQlResponse
+      if (payload.errors?.length && !payload.data) {
+        console.error('Morpho API returned errors:', payload.errors)
+        return {}
+      }
+
+      return this.normalizeVaultAprEstimates(payload)
+    } catch (error) {
+      console.error('Error fetching Morpho vault APRs:', error)
+      return {}
+    }
+  }
+
+  private normalizeVaultAprEstimates(
+    payload: MorphoGraphQlResponse,
+  ): Record<string, MorphoVaultAprEstimate> {
+    const estimates: Record<string, MorphoVaultAprEstimate> = {}
+
+    for (const vault of payload.data?.vaults?.items || []) {
+      if (!vault.address) {
+        continue
+      }
+
+      estimates[vault.address.toLowerCase()] = {
+        baseAPY: toFiniteNumber(vault.state?.apy),
+        rewardsAPR: sumNonKatRewardsAPR(vault.state?.allRewards),
+      }
+    }
+
+    for (const vault of payload.data?.vaultV2s?.items || []) {
+      if (!vault.address) {
+        continue
+      }
+
+      estimates[vault.address.toLowerCase()] = {
+        baseAPY: toFiniteNumber(vault.avgNetApyExcludingRewards),
+        rewardsAPR: sumNonKatRewardsAPR(vault.rewards),
+      }
+    }
+
+    return estimates
+  }
+}

--- a/src/app/services/externalApis/yearnApi.test.ts
+++ b/src/app/services/externalApis/yearnApi.test.ts
@@ -13,6 +13,7 @@ vi.mock('../aprCalcs/debugLogger', () => ({
 }))
 
 import { YearnApiService } from './yearnApi'
+import type { YearnVault } from '../../types'
 
 const makeOkResponse = (data: unknown) =>
   Promise.resolve({
@@ -155,5 +156,65 @@ describe('YearnApiService', () => {
         reason: 'fetched_from_kong',
       }),
     )
+  })
+
+  it('selects active Morpho compounders only for replacement APRs', () => {
+    const vault: YearnVault = {
+      address: '0x00000000000000000000000000000000000000aa',
+      symbol: 'yvvbUSDC',
+      name: 'USDC yVault',
+      chainID: 747474,
+      apr: {
+        netAPR: 0,
+      },
+      strategies: [
+        {
+          address: '0x0000000000000000000000000000000000000001',
+          name: 'Morpho Yearn USDC Compounder',
+          details: {
+            totalDebt: '100',
+            totalGain: '0',
+            totalLoss: '0',
+            lastReport: 0,
+          },
+        },
+        {
+          address: '0x0000000000000000000000000000000000000002',
+          name: 'Morpho vbWBTC/yvUSDC Lender Borrower',
+          details: {
+            totalDebt: '100',
+            totalGain: '0',
+            totalLoss: '0',
+            lastReport: 0,
+          },
+        },
+        {
+          address: '0x0000000000000000000000000000000000000003',
+          name: 'Morpho Inactive USDC Compounder',
+          details: {
+            totalDebt: '0',
+            totalGain: '0',
+            totalLoss: '0',
+            lastReport: 0,
+          },
+        },
+        {
+          address: '0x0000000000000000000000000000000000000004',
+          name: 'Steer USDC Compounder',
+          details: {
+            totalDebt: '100',
+            totalGain: '0',
+            totalLoss: '0',
+            lastReport: 0,
+          },
+        },
+      ],
+    }
+
+    const service = new YearnApiService()
+
+    expect(service.getActiveMorphoCompounderStrategies(vault)).toEqual([
+      '0x0000000000000000000000000000000000000001',
+    ])
   })
 })

--- a/src/app/services/externalApis/yearnApi.ts
+++ b/src/app/services/externalApis/yearnApi.ts
@@ -426,6 +426,21 @@ export class YearnApiService {
       .map((strategy): string => strategy.address)
   }
 
+  getActiveMorphoCompounderStrategies(vault: YearnVault): string[] {
+    return vault.strategies
+      .filter((strategy): boolean =>
+        Boolean(
+          strategy.name?.includes('Morpho') &&
+            strategy.name?.includes('Compounder') &&
+            !strategy.name?.includes('Lender Borrower') &&
+            strategy.details?.totalDebt &&
+            strategy.details.totalDebt !== '0' &&
+            strategy.details.totalDebt !== '0x0'
+        )
+      )
+      .map((strategy): string => strategy.address)
+  }
+
   getAutoCompoundedAPY(vault: YearnVault): number {
     return vault.apr?.netAPR || 0
   }


### PR DESCRIPTION
### Summary
Add a Morpho API APR replacement path for active Morpho compounder strategies only. The service now uses Morpho base APY plus non-KAT reward APRs for those compounders and writes the weighted result to the existing `apr.forwardAPR.netAPR` field.

Refs #49
Closes #55 

### How to review
Start with `src/app/services/externalApis/morphoApi.ts` for the Morpho GraphQL normalization, then review `src/app/services/aprCalcs/morphoUnderlyingAprCalculator.ts` for the replacement APR calculation. The final wiring is in `src/app/services/dataCache.ts`.

This intentionally leaves Steer, Morpho lender-borrower strategies, Kong ingestion, webhook output, and public strategy-level fields unchanged.

### Test plan
- [ ] Manual: Run `bun run dev` and inspect `/api/vaults` for active Morpho compounder vaults, confirming `apr.netAPR` remains historical and `apr.forwardAPR.netAPR` is populated.
- [x] Automated: `bun run test:run`
- [x] Automated: `bun run lint`

### Risk / impact
Risk is limited to vault APR response calculation. The change adds a new external Morpho API dependency, but failures degrade to existing strategy APR behavior and do not fail `/api/vaults`.

No database migrations, webhook contract changes, Kong changes, or new public gross/net fields are included. Rollback is reverting this branch, which restores the prior APR aggregation path.
