### PR TITLE
Emit fee-adjusted Morpho forward APR/APY to Kong

### DIFF
--- a/src/app/api/webhook/route.test.ts
+++ b/src/app/api/webhook/route.test.ts
@@ -44,6 +44,9 @@ describe('/api/webhook route', () => {
   })
 
   it('returns vault-level components plus strategy-addressed KAT APR rows', async () => {
+    const forwardNetAPR = 0.0789
+    const forwardNetAPY = (1 + forwardNetAPR / 52) ** 52 - 1
+
     mocks.mockGenerateVaultAPRData.mockResolvedValue({
       [VAULT_ADDRESS.toLowerCase()]: {
         address: VAULT_ADDRESS,
@@ -72,6 +75,18 @@ describe('/api/webhook route', () => {
           },
         ],
         apr: {
+          forwardAPR: {
+            type: '',
+            netAPR: forwardNetAPR,
+            composite: {
+              boost: null,
+              poolAPY: null,
+              boostedAPR: null,
+              baseAPR: null,
+              cvxAPR: null,
+              rewardsAPR: null,
+            },
+          },
           extra: {
             katanaAppRewardsAPR: 0.1234,
             fixedRateKatanaRewards: 0,
@@ -145,6 +160,24 @@ describe('/api/webhook route', () => {
       },
       {
         chainId: 747474,
+        address: REQUEST_VAULT_ADDRESS,
+        label: 'katana',
+        component: 'netAPR',
+        value: forwardNetAPR,
+        blockNumber: '123',
+        blockTime: '456',
+      },
+      {
+        chainId: 747474,
+        address: REQUEST_VAULT_ADDRESS,
+        label: 'katana',
+        component: 'netAPY',
+        value: forwardNetAPY,
+        blockNumber: '123',
+        blockTime: '456',
+      },
+      {
+        chainId: 747474,
         address: STRATEGY_ADDRESS,
         label: 'katana',
         component: 'katRewardsAPR',
@@ -162,5 +195,157 @@ describe('/api/webhook route', () => {
         blockTime: '456',
       },
     ])
+  })
+
+  it('emits zero forward net APR and APY rows', async () => {
+    mocks.mockGenerateVaultAPRData.mockResolvedValue({
+      [VAULT_ADDRESS.toLowerCase()]: {
+        address: VAULT_ADDRESS,
+        symbol: 'yvKAT',
+        name: 'KAT Vault',
+        chainID: 747474,
+        strategies: [],
+        apr: {
+          forwardAPR: {
+            type: '',
+            netAPR: 0,
+            composite: {
+              boost: null,
+              poolAPY: null,
+              boostedAPR: null,
+              baseAPR: null,
+              cvxAPR: null,
+              rewardsAPR: null,
+            },
+          },
+          extra: {},
+        },
+      },
+    })
+
+    const response = await POST(
+      buildSignedRequest({
+        vaults: [REQUEST_VAULT_ADDRESS],
+        chainId: 747474,
+        blockNumber: '123',
+        blockTime: '456',
+        subscription: {
+          labels: ['katana-estimated-apr'],
+        },
+      }),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toContainEqual({
+      chainId: 747474,
+      address: REQUEST_VAULT_ADDRESS,
+      label: 'katana-estimated-apr',
+      component: 'netAPR',
+      value: 0,
+      blockNumber: '123',
+      blockTime: '456',
+    })
+    expect(body).toContainEqual({
+      chainId: 747474,
+      address: REQUEST_VAULT_ADDRESS,
+      label: 'katana-estimated-apr',
+      component: 'netAPY',
+      value: 0,
+      blockNumber: '123',
+      blockTime: '456',
+    })
+  })
+
+  it('does not emit forward APR or APY rows for null, missing, or non-finite values', async () => {
+    const nullForwardAddress = '0x00000000000000000000000000000000000000a1'
+    const missingForwardAddress = '0x00000000000000000000000000000000000000a2'
+    const nonFiniteForwardAddress = '0x00000000000000000000000000000000000000a3'
+
+    mocks.mockGenerateVaultAPRData.mockResolvedValue({
+      [nullForwardAddress]: {
+        address: nullForwardAddress,
+        symbol: 'yvNULL',
+        name: 'Null Forward Vault',
+        chainID: 747474,
+        strategies: [],
+        apr: {
+          forwardAPR: {
+            type: '',
+            netAPR: null,
+            composite: {
+              boost: null,
+              poolAPY: null,
+              boostedAPR: null,
+              baseAPR: null,
+              cvxAPR: null,
+              rewardsAPR: null,
+            },
+          },
+          extra: {},
+        },
+      },
+      [missingForwardAddress]: {
+        address: missingForwardAddress,
+        symbol: 'yvMISS',
+        name: 'Missing Forward Vault',
+        chainID: 747474,
+        strategies: [],
+        apr: {
+          extra: {},
+        },
+      },
+      [nonFiniteForwardAddress]: {
+        address: nonFiniteForwardAddress,
+        symbol: 'yvINF',
+        name: 'Non-finite Forward Vault',
+        chainID: 747474,
+        strategies: [],
+        apr: {
+          forwardAPR: {
+            type: '',
+            netAPR: Number.POSITIVE_INFINITY,
+            composite: {
+              boost: null,
+              poolAPY: null,
+              boostedAPR: null,
+              baseAPR: null,
+              cvxAPR: null,
+              rewardsAPR: null,
+            },
+          },
+          extra: {},
+        },
+      },
+    })
+
+    const response = await POST(
+      buildSignedRequest({
+        vaults: [
+          nullForwardAddress,
+          missingForwardAddress,
+          nonFiniteForwardAddress,
+        ],
+        chainId: 747474,
+        blockNumber: '123',
+        blockTime: '456',
+        subscription: {
+          labels: ['katana-estimated-apr'],
+        },
+      }),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).not.toContainEqual(
+      expect.objectContaining({
+        component: 'netAPR',
+      }),
+    )
+    expect(body).not.toContainEqual(
+      expect.objectContaining({
+        component: 'netAPY',
+      }),
+    )
   })
 })

--- a/src/app/api/webhook/route.ts
+++ b/src/app/api/webhook/route.ts
@@ -33,6 +33,7 @@ interface ParsedWebhookBody {
 }
 
 const STRATEGY_APR_COMPONENT = 'katRewardsAPR'
+const COMPOUNDING_PERIODS_PER_YEAR = 52
 
 function verifyWebhookSignature(
   signatureHeader: string,
@@ -115,6 +116,36 @@ function buildStrategyOutputs(
   })
 }
 
+function buildForwardAPROutputs(
+  address: string,
+  forwardNetAPR: number | null | undefined,
+  base: Omit<KongOutput, 'address' | 'component' | 'value'>,
+): KongOutput[] {
+  const netAPR = toFiniteNumber(forwardNetAPR)
+
+  if (netAPR == null) {
+    return []
+  }
+
+  return [
+    {
+      ...base,
+      address,
+      component: 'netAPR',
+      value: netAPR,
+    },
+    {
+      ...base,
+      address,
+      component: 'netAPY',
+      value:
+        (1 + netAPR / COMPOUNDING_PERIODS_PER_YEAR) **
+          COMPOUNDING_PERIODS_PER_YEAR -
+        1,
+    },
+  ]
+}
+
 export async function POST(req: NextRequest): Promise<Response> {
   const secret = process.env.KONG_WEBHOOK_SECRET
   if (!secret) {
@@ -152,6 +183,13 @@ export async function POST(req: NextRequest): Promise<Response> {
         outputs.push({ ...base, address, component, value: extra[component] ?? 0 })
       }
 
+      outputs.push(
+        ...buildForwardAPROutputs(
+          address,
+          vault.apr?.forwardAPR?.netAPR,
+          base,
+        ),
+      )
       outputs.push(...buildStrategyOutputs(vault.strategies || [], base))
     }
 

--- a/src/app/services/dataCache.test.ts
+++ b/src/app/services/dataCache.test.ts
@@ -319,6 +319,10 @@ describe('DataCacheService.generateVaultAPRData', () => {
     const vault = makeVault({
       apr: {
         netAPR: 0.0123,
+        fees: {
+          management: 0.02,
+          performance: 0.1,
+        },
         forwardAPR: {
           type: '',
           netAPR: null,
@@ -396,7 +400,7 @@ describe('DataCacheService.generateVaultAPRData', () => {
 
     expect(data[vault.address].apr?.netAPR).toBe(0.0123)
     expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(
-      0.10 * 0.5 + 0.04 * 0.25,
+      ((0.10 * 0.5 + 0.04 * 0.25) - 0.02) * (1 - 0.1),
     )
   })
 
@@ -446,5 +450,156 @@ describe('DataCacheService.generateVaultAPRData', () => {
 
     expect(data[vault.address].apr?.netAPR).toBe(0.02)
     expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(0.015)
+  })
+
+  it('floors fee-adjusted forward APR at half of positive gross APR', async () => {
+    const morphoStrategyAddress =
+      '0x00000000000000000000000000000000000000f5'
+    const vault = makeVault({
+      apr: {
+        netAPR: 0.02,
+        fees: {
+          management: 0.009,
+          performance: 0,
+        },
+      },
+      tvl: {
+        totalAssets: '100',
+        tvl: 100,
+        price: 1,
+      },
+      strategies: [
+        {
+          address: morphoStrategyAddress,
+          name: 'Morpho Yearn USDC Compounder',
+          status: 'active',
+          netAPR: 0,
+          details: {
+            totalDebt: '100',
+            totalGain: '0',
+            totalLoss: '0',
+            lastReport: 0,
+            debtRatio: 10000,
+          },
+        },
+      ],
+    })
+    mocks.mockGetVaults.mockResolvedValue([vault])
+    mocks.mockCalculateMorphoUnderlyingVaultAPRs.mockResolvedValue({
+      [vault.address]: [
+        {
+          strategyAddress: morphoStrategyAddress,
+          morphoVaultAddress:
+            '0x00000000000000000000000000000000000000a3',
+          replacementAPR: 0.01,
+          usedMorphoApi: true,
+        },
+      ],
+    })
+
+    const service = new DataCacheService()
+    const data = await service.generateVaultAPRData()
+
+    expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(0.005)
+  })
+
+  it('returns zero forward APR for zero or negative gross APR before fees', async () => {
+    const morphoStrategyAddress =
+      '0x00000000000000000000000000000000000000f6'
+    const vault = makeVault({
+      apr: {
+        netAPR: 0.02,
+        fees: {
+          management: 0.01,
+          performance: 0.2,
+        },
+      },
+      tvl: {
+        totalAssets: '100',
+        tvl: 100,
+        price: 1,
+      },
+      strategies: [
+        {
+          address: morphoStrategyAddress,
+          name: 'Morpho Yearn USDC Compounder',
+          status: 'active',
+          details: {
+            totalDebt: '100',
+            totalGain: '0',
+            totalLoss: '0',
+            lastReport: 0,
+            debtRatio: 10000,
+          },
+        },
+      ],
+    })
+    mocks.mockGetVaults.mockResolvedValue([vault])
+    mocks.mockCalculateMorphoUnderlyingVaultAPRs.mockResolvedValue({
+      [vault.address]: [
+        {
+          strategyAddress: morphoStrategyAddress,
+          morphoVaultAddress:
+            '0x00000000000000000000000000000000000000a4',
+          replacementAPR: -0.01,
+          usedMorphoApi: true,
+        },
+      ],
+    })
+
+    const service = new DataCacheService()
+    const data = await service.generateVaultAPRData()
+
+    expect(data[vault.address].apr?.forwardAPR?.netAPR).toBe(0)
+  })
+
+  it('treats missing or non-finite fee values as zero fees', async () => {
+    const morphoStrategyAddress =
+      '0x00000000000000000000000000000000000000f7'
+    const vault = makeVault({
+      apr: {
+        netAPR: 0.02,
+        fees: {
+          management: Number.NaN,
+          performance: Number.POSITIVE_INFINITY,
+        },
+      },
+      tvl: {
+        totalAssets: '100',
+        tvl: 100,
+        price: 1,
+      },
+      strategies: [
+        {
+          address: morphoStrategyAddress,
+          name: 'Morpho Yearn USDC Compounder',
+          status: 'active',
+          details: {
+            totalDebt: '100',
+            totalGain: '0',
+            totalLoss: '0',
+            lastReport: 0,
+            debtRatio: 10000,
+          },
+        },
+      ],
+    })
+    mocks.mockGetVaults.mockResolvedValue([vault])
+    mocks.mockCalculateMorphoUnderlyingVaultAPRs.mockResolvedValue({
+      [vault.address]: [
+        {
+          strategyAddress: morphoStrategyAddress,
+          morphoVaultAddress:
+            '0x00000000000000000000000000000000000000a5',
+          replacementAPR: 0.07,
+          usedMorphoApi: true,
+        },
+      ],
+    })
+
+    const service = new DataCacheService()
+    const data = await service.generateVaultAPRData()
+
+    expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(0.07)
   })
 })

--- a/src/app/services/dataCache.test.ts
+++ b/src/app/services/dataCache.test.ts
@@ -397,10 +397,15 @@ describe('DataCacheService.generateVaultAPRData', () => {
 
     const service = new DataCacheService()
     const data = await service.generateVaultAPRData()
+    const morphoGross = 0.10 * 0.5
+    const steerGross = 0.04 * 0.25
 
     expect(data[vault.address].apr?.netAPR).toBe(0.0123)
     expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(
-      ((0.10 * 0.5 + 0.04 * 0.25) - 0.02) * (1 - 0.1),
+      morphoGross -
+        (0.02 * 0.5 + morphoGross * 0.1) +
+        (steerGross -
+          Math.min(0.02 * 0.25 + steerGross * 0.1, steerGross * 0.5)),
     )
   })
 
@@ -496,7 +501,7 @@ describe('DataCacheService.generateVaultAPRData', () => {
     expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeNull()
   })
 
-  it('floors fee-adjusted forward APR at half of positive gross APR', async () => {
+  it('caps total accountant fees at max fee percent of gross APR', async () => {
     const morphoStrategyAddress =
       '0x00000000000000000000000000000000000000f5'
     const vault = makeVault({
@@ -545,6 +550,57 @@ describe('DataCacheService.generateVaultAPRData', () => {
     const data = await service.generateVaultAPRData()
 
     expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(0.005)
+  })
+
+  it('applies performance fee to gross APR without reducing management fee', async () => {
+    const morphoStrategyAddress =
+      '0x00000000000000000000000000000000000000f8'
+    const vault = makeVault({
+      apr: {
+        netAPR: 0.02,
+        fees: {
+          management: 0.02,
+          performance: 0.1,
+          maxFee: 0.5,
+        },
+      },
+      tvl: {
+        totalAssets: '100',
+        tvl: 100,
+        price: 1,
+      },
+      strategies: [
+        {
+          address: morphoStrategyAddress,
+          name: 'Morpho Yearn USDC Compounder',
+          status: 'active',
+          details: {
+            totalDebt: '100',
+            totalGain: '0',
+            totalLoss: '0',
+            lastReport: 0,
+            debtRatio: 10000,
+          },
+        },
+      ],
+    })
+    mocks.mockGetVaults.mockResolvedValue([vault])
+    mocks.mockCalculateMorphoUnderlyingVaultAPRs.mockResolvedValue({
+      [vault.address]: [
+        {
+          strategyAddress: morphoStrategyAddress,
+          morphoVaultAddress:
+            '0x00000000000000000000000000000000000000a6',
+          replacementAPR: 0.08,
+          usedMorphoApi: true,
+        },
+      ],
+    })
+
+    const service = new DataCacheService()
+    const data = await service.generateVaultAPRData()
+
+    expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(0.052)
   })
 
   it('returns zero forward APR for zero or negative gross APR before fees', async () => {

--- a/src/app/services/dataCache.test.ts
+++ b/src/app/services/dataCache.test.ts
@@ -452,6 +452,50 @@ describe('DataCacheService.generateVaultAPRData', () => {
     expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(0.015)
   })
 
+  it('keeps forward APR unchanged when there are no Morpho replacement results', async () => {
+    const vault = makeVault({
+      apr: {
+        netAPR: 0.02,
+        forwardAPR: {
+          type: '',
+          netAPR: null,
+          composite: {
+            boost: null,
+            poolAPY: null,
+            boostedAPR: null,
+            baseAPR: null,
+            cvxAPR: null,
+            rewardsAPR: null,
+          },
+        },
+      },
+    })
+    mocks.mockGetVaults.mockResolvedValue([vault])
+    mocks.mockCalculateYearnVaultAPRs.mockResolvedValue({
+      [vault.address]: [
+        {
+          vaultName: vault.name,
+          vaultAddress: vault.address,
+          poolType: 'yearn',
+          breakdown: {
+            apr: 10,
+            token: {
+              address: '0x00000000000000000000000000000000000000bb',
+              symbol: 'KAT',
+              decimals: 18,
+            },
+            weight: 0,
+          },
+        },
+      ],
+    })
+
+    const service = new DataCacheService()
+    const data = await service.generateVaultAPRData()
+
+    expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeNull()
+  })
+
   it('floors fee-adjusted forward APR at half of positive gross APR', async () => {
     const morphoStrategyAddress =
       '0x00000000000000000000000000000000000000f5'

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -36,6 +36,8 @@ interface StrategyRewardSummary {
   underlyingContract?: string
 }
 
+const KATANA_ACCOUNTANT_DEFAULT_MAX_FEE = 0.5
+
 export class DataCacheService {
   private yearnApi: YearnApiService
   private yearnAprCalculator: YearnAprCalculator
@@ -282,7 +284,7 @@ export class DataCacheService {
       ]),
     )
 
-    const grossForwardAPR = (vault.strategies || []).reduce((sum, strategy) => {
+    const netAPR = (vault.strategies || []).reduce((sum, strategy) => {
       const debtShare = this.getStrategyDebtShare(strategy, vault)
       if (debtShare <= 0) {
         return sum
@@ -294,9 +296,10 @@ export class DataCacheService {
       const strategyAPR =
         replacementAPR ?? this.getCurrentStrategyAPR(strategy)
 
-      return sum + debtShare * strategyAPR
+      return (
+        sum + this.computeNetStrategyForwardAPR(strategyAPR, debtShare, vault)
+      )
     }, 0)
-    const netAPR = this.computeNetForwardAPR(grossForwardAPR, vault)
 
     return {
       type: vault.apr?.forwardAPR?.type || '',
@@ -312,20 +315,38 @@ export class DataCacheService {
     }
   }
 
-  private computeNetForwardAPR(grossAPR: number, vault: YearnVault): number {
-    if (grossAPR <= 0) {
+  private computeNetStrategyForwardAPR(
+    strategyAPR: number,
+    debtShare: number,
+    vault: YearnVault,
+  ): number {
+    const grossContribution = strategyAPR * debtShare
+    if (grossContribution <= 0) {
       return 0
     }
 
     const managementFee = this.getFiniteFee(vault.apr?.fees?.management)
     const performanceFee = this.getFiniteFee(vault.apr?.fees?.performance)
-    const netAPR = (grossAPR - managementFee) * (1 - performanceFee)
+    const maxFee = this.getFiniteFee(
+      vault.apr?.fees?.maxFee,
+      KATANA_ACCOUNTANT_DEFAULT_MAX_FEE,
+    )
+    const managementFeeContribution = managementFee * debtShare
+    const uncappedFees =
+      managementFeeContribution + grossContribution * performanceFee
+    const totalFees =
+      maxFee > 0
+        ? Math.min(uncappedFees, grossContribution * maxFee)
+        : uncappedFees
+    const netAPR = grossContribution - totalFees
 
-    return Math.max(netAPR, grossAPR / 2)
+    return Math.max(netAPR, 0)
   }
 
-  private getFiniteFee(value: number | undefined): number {
-    return typeof value === 'number' && Number.isFinite(value) ? value : 0
+  private getFiniteFee(value: number | undefined, fallback = 0): number {
+    return typeof value === 'number' && Number.isFinite(value)
+      ? value
+      : fallback
   }
 
   private getStrategyDebtShare(

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -282,7 +282,7 @@ export class DataCacheService {
       ]),
     )
 
-    const netAPR = (vault.strategies || []).reduce((sum, strategy) => {
+    const grossForwardAPR = (vault.strategies || []).reduce((sum, strategy) => {
       const debtShare = this.getStrategyDebtShare(strategy, vault)
       if (debtShare <= 0) {
         return sum
@@ -296,6 +296,7 @@ export class DataCacheService {
 
       return sum + debtShare * strategyAPR
     }, 0)
+    const netAPR = this.computeNetForwardAPR(grossForwardAPR, vault)
 
     return {
       type: vault.apr?.forwardAPR?.type || '',
@@ -309,6 +310,22 @@ export class DataCacheService {
         rewardsAPR: null,
       },
     }
+  }
+
+  private computeNetForwardAPR(grossAPR: number, vault: YearnVault): number {
+    if (grossAPR <= 0) {
+      return 0
+    }
+
+    const managementFee = this.getFiniteFee(vault.apr?.fees?.management)
+    const performanceFee = this.getFiniteFee(vault.apr?.fees?.performance)
+    const netAPR = (grossAPR - managementFee) * (1 - performanceFee)
+
+    return Math.max(netAPR, grossAPR / 2)
+  }
+
+  private getFiniteFee(value: number | undefined): number {
+    return typeof value === 'number' && Number.isFinite(value) ? value : 0
   }
 
   private getStrategyDebtShare(

--- a/src/app/services/externalApis/yearnApi.test.ts
+++ b/src/app/services/externalApis/yearnApi.test.ts
@@ -117,6 +117,7 @@ describe('YearnApiService', () => {
         fees: {
           management: 0.0025,
           performance: 0.1,
+          maxFee: 0.5,
         },
         pricePerShare: {
           today: 1,

--- a/src/app/services/externalApis/yearnApi.ts
+++ b/src/app/services/externalApis/yearnApi.ts
@@ -81,6 +81,7 @@ type KongVaultSnapshot = {
   fees?: {
     managementFee?: number
     performanceFee?: number
+    maxFee?: number
   } | null
   composition?: KongVaultCompositionItem[]
 }
@@ -116,6 +117,7 @@ const toStringValue = (value: unknown, fallback = '0'): string =>
   value === null || value === undefined ? fallback : String(value)
 
 const normalizeBasisPoints = (value: unknown): number => toNumber(value) / 10_000
+const KATANA_ACCOUNTANT_DEFAULT_MAX_FEE_BPS = 5_000
 
 const normalizeShareValue = (
   value: unknown,
@@ -245,6 +247,9 @@ const mapKongAprToYearnApr = (snapshot: KongVaultSnapshot): YearnVaultAPY => {
       ? {
           management: normalizeBasisPoints(snapshot.fees.managementFee),
           performance: normalizeBasisPoints(snapshot.fees.performanceFee),
+          maxFee: normalizeBasisPoints(
+            snapshot.fees.maxFee ?? KATANA_ACCOUNTANT_DEFAULT_MAX_FEE_BPS,
+          ),
         }
       : undefined,
     points: {

--- a/src/app/types/yearn.ts
+++ b/src/app/types/yearn.ts
@@ -52,6 +52,7 @@ export interface YearnVaultPoints {
 export interface YearnVaultFees {
   performance: number
   management: number
+  maxFee?: number
 }
 
 export interface YearnVaultAPY {


### PR DESCRIPTION
### Summary
Applies the Yearn vault fee schedule to the weighted Morpho forward APR from #54 before assigning `apr.forwardAPR.netAPR`, so the field is semantically net. The webhook now also emits vault-addressed `netAPR` and weekly-compounded `netAPY` rows whenever the computed forward APR is finite, letting Kong expose fee-adjusted Katana estimated performance for yearn.fi.

Closes #56

### How to review
- `src/app/services/dataCache.ts` — fee adjustment happens once on the final weighted gross APR, following Kong's `computeNetApr` convention: non-positive gross returns `0`, otherwise `(grossAPR - managementFee) * (1 - performanceFee)` floored at `grossAPR / 2`. Missing/non-finite fees are treated as `0`. Historical `apr.netAPR` is untouched.
- `src/app/api/webhook/route.ts` — new `buildForwardAPROutputs` emits `netAPR` and `netAPY` (`(1 + netAPR/52)^52 - 1`) rows; a finite `0` still emits (the guard is a null check, not truthiness). Existing extra component rows and strategy `katRewardsAPR` rows are unchanged.
- No new public API response fields.

### Test plan
- [x] Automated: `bun run test:run` — 66 tests pass, including new coverage for fee math (zero/negative gross, normal fees, `grossAPR / 2` floor), weighted aggregation, zero/null/missing/non-finite forward APR webhook cases, and vaults without a Morpho replacement result
- [x] Automated: `bun run lint` — clean

### Risk / impact
- Kong will start receiving vault-level `katana-estimated-apr/netAPR` and `netAPY` rows; Kong already maps these to `performance.estimated.apr`/`apy`, so no Kong change is required.
- The forward `netAPR` value in API responses drops by the fee adjustment — expected, since it now matches the Kong oracle values it replaces.
- Rollback: revert the fee adjustment and row emission; historical `apr.netAPR` behavior is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### Addendum: fee accounting superseded by #58 before merge

#58 merged into this branch prior to landing on main, replacing the fee model described above. The "How to review" notes on `dataCache.ts` — fee adjustment applied **once on the final weighted gross APR**, per Kong's `computeNetApr` convention with the `grossAPR / 2` floor — **do not describe the merged code.**

What actually shipped in the squash commit (`158659f`):

- Fees are applied **per strategy contribution** before aggregation, mirroring the on-chain Yearn V3 accountant, not once at the vault level.
- Per strategy: `grossContribution = strategyAPR × debtShare`; the management fee is weighted by debt share; the performance fee applies to the gross contribution; combined fees are **capped at `maxFee × grossContribution`** rather than floored at `grossAPR / 2`.
- `maxFee` is mapped from Kong fee data and defaults to `0.5`, matching the current Katana accountant configuration (25 bps management / 1000 bps performance / 5000 bps max).
- Zero or negative gross strategy contributions net to zero.
- `forwardAPR.netAPR` is the sum of per-strategy net contributions. Everything else above stands: historical `apr.netAPR` is untouched, and the webhook `netAPR`/`netAPY` row emission is as described.

Practical impact: results are near-identical for typical vaults but diverge where the max-fee cap binds (low-yield vaults such as WBTC) and for partially idle vaults, where management fees are now weighted by deployed debt share. Rationale and tests are in #58.
