### PR TITLE
Adjust fees to match onchain

### DIFF
--- a/src/app/services/dataCache.test.ts
+++ b/src/app/services/dataCache.test.ts
@@ -400,7 +400,8 @@ describe('DataCacheService.generateVaultAPRData', () => {
 
     expect(data[vault.address].apr?.netAPR).toBe(0.0123)
     expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(
-      ((0.10 * 0.5 + 0.04 * 0.25) - 0.02) * (1 - 0.1),
+      (0.10 * 0.5 + 0.04 * 0.25) -
+        (0.02 + (0.10 * 0.5 + 0.04 * 0.25) * 0.1),
     )
   })
 
@@ -496,7 +497,7 @@ describe('DataCacheService.generateVaultAPRData', () => {
     expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeNull()
   })
 
-  it('floors fee-adjusted forward APR at half of positive gross APR', async () => {
+  it('caps total accountant fees at max fee percent of gross APR', async () => {
     const morphoStrategyAddress =
       '0x00000000000000000000000000000000000000f5'
     const vault = makeVault({
@@ -545,6 +546,57 @@ describe('DataCacheService.generateVaultAPRData', () => {
     const data = await service.generateVaultAPRData()
 
     expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(0.005)
+  })
+
+  it('applies performance fee to gross APR without reducing management fee', async () => {
+    const morphoStrategyAddress =
+      '0x00000000000000000000000000000000000000f8'
+    const vault = makeVault({
+      apr: {
+        netAPR: 0.02,
+        fees: {
+          management: 0.02,
+          performance: 0.1,
+          maxFee: 0.5,
+        },
+      },
+      tvl: {
+        totalAssets: '100',
+        tvl: 100,
+        price: 1,
+      },
+      strategies: [
+        {
+          address: morphoStrategyAddress,
+          name: 'Morpho Yearn USDC Compounder',
+          status: 'active',
+          details: {
+            totalDebt: '100',
+            totalGain: '0',
+            totalLoss: '0',
+            lastReport: 0,
+            debtRatio: 10000,
+          },
+        },
+      ],
+    })
+    mocks.mockGetVaults.mockResolvedValue([vault])
+    mocks.mockCalculateMorphoUnderlyingVaultAPRs.mockResolvedValue({
+      [vault.address]: [
+        {
+          strategyAddress: morphoStrategyAddress,
+          morphoVaultAddress:
+            '0x00000000000000000000000000000000000000a6',
+          replacementAPR: 0.08,
+          usedMorphoApi: true,
+        },
+      ],
+    })
+
+    const service = new DataCacheService()
+    const data = await service.generateVaultAPRData()
+
+    expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(0.052)
   })
 
   it('returns zero forward APR for zero or negative gross APR before fees', async () => {

--- a/src/app/services/dataCache.test.ts
+++ b/src/app/services/dataCache.test.ts
@@ -397,11 +397,15 @@ describe('DataCacheService.generateVaultAPRData', () => {
 
     const service = new DataCacheService()
     const data = await service.generateVaultAPRData()
+    const morphoGross = 0.10 * 0.5
+    const steerGross = 0.04 * 0.25
 
     expect(data[vault.address].apr?.netAPR).toBe(0.0123)
     expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(
-      (0.10 * 0.5 + 0.04 * 0.25) -
-        (0.02 + (0.10 * 0.5 + 0.04 * 0.25) * 0.1),
+      morphoGross -
+        (0.02 * 0.5 + morphoGross * 0.1) +
+        (steerGross -
+          Math.min(0.02 * 0.25 + steerGross * 0.1, steerGross * 0.5)),
     )
   })
 

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -284,7 +284,7 @@ export class DataCacheService {
       ]),
     )
 
-    const grossForwardAPR = (vault.strategies || []).reduce((sum, strategy) => {
+    const netAPR = (vault.strategies || []).reduce((sum, strategy) => {
       const debtShare = this.getStrategyDebtShare(strategy, vault)
       if (debtShare <= 0) {
         return sum
@@ -296,9 +296,10 @@ export class DataCacheService {
       const strategyAPR =
         replacementAPR ?? this.getCurrentStrategyAPR(strategy)
 
-      return sum + debtShare * strategyAPR
+      return (
+        sum + this.computeNetStrategyForwardAPR(strategyAPR, debtShare, vault)
+      )
     }, 0)
-    const netAPR = this.computeNetForwardAPR(grossForwardAPR, vault)
 
     return {
       type: vault.apr?.forwardAPR?.type || '',
@@ -314,8 +315,13 @@ export class DataCacheService {
     }
   }
 
-  private computeNetForwardAPR(grossAPR: number, vault: YearnVault): number {
-    if (grossAPR <= 0) {
+  private computeNetStrategyForwardAPR(
+    strategyAPR: number,
+    debtShare: number,
+    vault: YearnVault,
+  ): number {
+    const grossContribution = strategyAPR * debtShare
+    if (grossContribution <= 0) {
       return 0
     }
 
@@ -325,10 +331,14 @@ export class DataCacheService {
       vault.apr?.fees?.maxFee,
       KATANA_ACCOUNTANT_DEFAULT_MAX_FEE,
     )
-    const uncappedFees = managementFee + grossAPR * performanceFee
+    const managementFeeContribution = managementFee * debtShare
+    const uncappedFees =
+      managementFeeContribution + grossContribution * performanceFee
     const totalFees =
-      maxFee > 0 ? Math.min(uncappedFees, grossAPR * maxFee) : uncappedFees
-    const netAPR = grossAPR - totalFees
+      maxFee > 0
+        ? Math.min(uncappedFees, grossContribution * maxFee)
+        : uncappedFees
+    const netAPR = grossContribution - totalFees
 
     return Math.max(netAPR, 0)
   }

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -36,6 +36,8 @@ interface StrategyRewardSummary {
   underlyingContract?: string
 }
 
+const KATANA_ACCOUNTANT_DEFAULT_MAX_FEE = 0.5
+
 export class DataCacheService {
   private yearnApi: YearnApiService
   private yearnAprCalculator: YearnAprCalculator
@@ -319,13 +321,22 @@ export class DataCacheService {
 
     const managementFee = this.getFiniteFee(vault.apr?.fees?.management)
     const performanceFee = this.getFiniteFee(vault.apr?.fees?.performance)
-    const netAPR = (grossAPR - managementFee) * (1 - performanceFee)
+    const maxFee = this.getFiniteFee(
+      vault.apr?.fees?.maxFee,
+      KATANA_ACCOUNTANT_DEFAULT_MAX_FEE,
+    )
+    const uncappedFees = managementFee + grossAPR * performanceFee
+    const totalFees =
+      maxFee > 0 ? Math.min(uncappedFees, grossAPR * maxFee) : uncappedFees
+    const netAPR = grossAPR - totalFees
 
-    return Math.max(netAPR, grossAPR / 2)
+    return Math.max(netAPR, 0)
   }
 
-  private getFiniteFee(value: number | undefined): number {
-    return typeof value === 'number' && Number.isFinite(value) ? value : 0
+  private getFiniteFee(value: number | undefined, fallback = 0): number {
+    return typeof value === 'number' && Number.isFinite(value)
+      ? value
+      : fallback
   }
 
   private getStrategyDebtShare(

--- a/src/app/services/externalApis/yearnApi.test.ts
+++ b/src/app/services/externalApis/yearnApi.test.ts
@@ -117,6 +117,7 @@ describe('YearnApiService', () => {
         fees: {
           management: 0.0025,
           performance: 0.1,
+          maxFee: 0.5,
         },
         pricePerShare: {
           today: 1,

--- a/src/app/services/externalApis/yearnApi.ts
+++ b/src/app/services/externalApis/yearnApi.ts
@@ -81,6 +81,7 @@ type KongVaultSnapshot = {
   fees?: {
     managementFee?: number
     performanceFee?: number
+    maxFee?: number
   } | null
   composition?: KongVaultCompositionItem[]
 }
@@ -116,6 +117,7 @@ const toStringValue = (value: unknown, fallback = '0'): string =>
   value === null || value === undefined ? fallback : String(value)
 
 const normalizeBasisPoints = (value: unknown): number => toNumber(value) / 10_000
+const KATANA_ACCOUNTANT_DEFAULT_MAX_FEE_BPS = 5_000
 
 const normalizeShareValue = (
   value: unknown,
@@ -245,6 +247,9 @@ const mapKongAprToYearnApr = (snapshot: KongVaultSnapshot): YearnVaultAPY => {
       ? {
           management: normalizeBasisPoints(snapshot.fees.managementFee),
           performance: normalizeBasisPoints(snapshot.fees.performanceFee),
+          maxFee: normalizeBasisPoints(
+            snapshot.fees.maxFee ?? KATANA_ACCOUNTANT_DEFAULT_MAX_FEE_BPS,
+          ),
         }
       : undefined,
     points: {

--- a/src/app/types/yearn.ts
+++ b/src/app/types/yearn.ts
@@ -52,6 +52,7 @@ export interface YearnVaultPoints {
 export interface YearnVaultFees {
   performance: number
   management: number
+  maxFee?: number
 }
 
 export interface YearnVaultAPY {


### PR DESCRIPTION
## Summary

Updates forward APR fee adjustment to match the Katana Yearn V3 accountant mechanics more closely.

The previous fee adjustment applied fees once at the vault aggregate level. That was not accurate for Katana vaults because the on-chain accountant charges fees during each strategy report, so management fees, performance fees, and the max-fee cap need to be modeled per strategy contribution before summing to the vault-level forward APR.

## Fee Mechanics

Katana vaults currently use a shared Yearn V3 accountant with:

- `managementFee = 25` bps
- `performanceFee = 1000` bps
- `maxFee = 5000` bps

The accountant logic is:

- management fee is charged on strategy debt over time
- performance fee is charged only on reported strategy gain
- total fees are capped by `maxFee` as a percent of that strategy’s gain

For forward APR estimation, this branch now mirrors that shape:

```ts
grossContribution = strategyAPR * debtShare
managementFeeContribution = managementFee * debtShare
uncappedFees = managementFeeContribution + grossContribution * performanceFee
totalFees = min(uncappedFees, grossContribution * maxFee)
netContribution = grossContribution - totalFees
```

The vault-level forward APR is then the sum of strategy-level net contributions.

## Why This Matters

Applying fees once after aggregating vault APR can misstate low-yield or partially idle vaults.

For example, if only 50% of a vault is deployed in a low-yield strategy, the management fee should be weighted by that 50% debt share. The previous aggregate-level calculation could subtract or cap fees against the whole vault-level gross APR, rather than against each reporting strategy’s gross contribution.

This is especially relevant for low APY vaults such as WBTC, where the 50% max-fee cap can be reached.

## Implementation Details

- Adds optional `fees.maxFee` to the internal Yearn vault fee type.
- Maps Kong fee data into `management`, `performance`, and `maxFee`.
- Defaults `maxFee` to `0.5` when Kong does not provide it, matching the current Katana accountant configuration.
- Moves forward APR fee adjustment into the strategy reduce path so each strategy is netted individually.
- Keeps zero or negative gross strategy APR contributions at zero.

## Testing

Added and updated coverage for:

- management fee plus performance fee without reducing management fee by the performance fee factor
- max-fee cap behavior on very low gross APR
- debt-weighted management fees when part of the vault is idle
- missing or non-finite fee values
- zero/negative gross APR behavior

Verified locally:

- `bun run test:run`
- `bun run lint`
- `bun run build`