### PR TITLE
fix: expose Morpho APR diagnostics and estimates

### DIFF
--- a/src/app/api/webhook/route.test.ts
+++ b/src/app/api/webhook/route.test.ts
@@ -43,7 +43,7 @@ describe('/api/webhook route', () => {
     mocks.mockGenerateVaultAPRData.mockReset()
   })
 
-  it('returns vault-level components plus strategy-addressed KAT APR rows', async () => {
+  it('returns vault-level components plus strategy-addressed estimated and KAT APR rows', async () => {
     const forwardNetAPR = 0.0789
     const forwardNetAPY = (1 + forwardNetAPR / 52) ** 52 - 1
 
@@ -203,6 +203,24 @@ describe('/api/webhook route', () => {
         chainId: 747474,
         address: STRATEGY_ADDRESS,
         label: 'katana',
+        component: 'netAPR',
+        value: 0.06,
+        blockNumber: '123',
+        blockTime: '456',
+      },
+      {
+        chainId: 747474,
+        address: STRATEGY_ADDRESS,
+        label: 'katana',
+        component: 'netAPY',
+        value: 0.0618,
+        blockNumber: '123',
+        blockTime: '456',
+      },
+      {
+        chainId: 747474,
+        address: STRATEGY_ADDRESS,
+        label: 'katana',
         component: 'katRewardsAPR',
         value: 0.123,
         blockNumber: '123',
@@ -218,6 +236,116 @@ describe('/api/webhook route', () => {
         blockTime: '456',
       },
     ])
+  })
+
+  it('emits strategy estimated APR and APY independently of KAT rewards', async () => {
+    const zeroEstimateAddress =
+      '0x00000000000000000000000000000000000000d1'
+    const invalidEstimateAddress =
+      '0x00000000000000000000000000000000000000d2'
+
+    mocks.mockGenerateVaultAPRData.mockResolvedValue({
+      [VAULT_ADDRESS.toLowerCase()]: {
+        address: VAULT_ADDRESS,
+        symbol: 'yvKAT',
+        name: 'KAT Vault',
+        chainID: 747474,
+        strategies: [
+          {
+            address: zeroEstimateAddress,
+            name: 'Morpho Strategy Without KAT',
+            morphoUnderlyingAPR: {
+              morphoVaultAddress:
+                '0x00000000000000000000000000000000000000e1',
+              usedMorphoApi: true,
+              morphoBaseAPR: 0,
+              morphoBaseAPY: 0,
+              morphoRewardsAPR: 0,
+              estimatedAPR: 0,
+              estimatedAPY: 0,
+            },
+          },
+          {
+            address: invalidEstimateAddress,
+            name: 'Invalid Morpho Estimate',
+            strategyRewardsAPR: 0.01,
+            morphoUnderlyingAPR: {
+              morphoVaultAddress:
+                '0x00000000000000000000000000000000000000e2',
+              usedMorphoApi: true,
+              morphoBaseAPR: 0,
+              morphoBaseAPY: 0,
+              morphoRewardsAPR: 0,
+              estimatedAPR: Number.POSITIVE_INFINITY,
+              estimatedAPY: Number.NaN,
+            },
+          },
+        ],
+        apr: {
+          extra: {},
+        },
+      },
+    })
+
+    const response = await POST(
+      buildSignedRequest({
+        vaults: [REQUEST_VAULT_ADDRESS],
+        chainId: 747474,
+        blockNumber: '123',
+        blockTime: '456',
+        subscription: {
+          labels: ['katana-estimated-apr'],
+        },
+      }),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toContainEqual({
+      chainId: 747474,
+      address: zeroEstimateAddress,
+      label: 'katana-estimated-apr',
+      component: 'netAPR',
+      value: 0,
+      blockNumber: '123',
+      blockTime: '456',
+    })
+    expect(body).toContainEqual({
+      chainId: 747474,
+      address: zeroEstimateAddress,
+      label: 'katana-estimated-apr',
+      component: 'netAPY',
+      value: 0,
+      blockNumber: '123',
+      blockTime: '456',
+    })
+    expect(body).not.toContainEqual(
+      expect.objectContaining({
+        address: zeroEstimateAddress,
+        component: 'katRewardsAPR',
+      }),
+    )
+    expect(body).not.toContainEqual(
+      expect.objectContaining({
+        address: invalidEstimateAddress,
+        component: 'netAPR',
+      }),
+    )
+    expect(body).not.toContainEqual(
+      expect.objectContaining({
+        address: invalidEstimateAddress,
+        component: 'netAPY',
+      }),
+    )
+    expect(body).toContainEqual({
+      chainId: 747474,
+      address: invalidEstimateAddress,
+      label: 'katana-estimated-apr',
+      component: 'katRewardsAPR',
+      value: 0.01,
+      blockNumber: '123',
+      blockTime: '456',
+    })
   })
 
   it('emits zero forward net APR and APY rows', async () => {

--- a/src/app/api/webhook/route.test.ts
+++ b/src/app/api/webhook/route.test.ts
@@ -58,6 +58,16 @@ describe('/api/webhook route', () => {
             address: STRATEGY_ADDRESS,
             name: 'Morpho Strategy',
             strategyRewardsAPR: 0.123,
+            morphoUnderlyingAPR: {
+              morphoVaultAddress:
+                '0x00000000000000000000000000000000000000ee',
+              usedMorphoApi: true,
+              morphoBaseAPR: 0.04,
+              morphoBaseAPY: 0.0408,
+              morphoRewardsAPR: 0.02,
+              estimatedAPR: 0.06,
+              estimatedAPY: 0.0618,
+            },
           },
           {
             address: SECOND_STRATEGY_ADDRESS,
@@ -86,6 +96,13 @@ describe('/api/webhook route', () => {
               cvxAPR: null,
               rewardsAPR: null,
             },
+            morphoUnderlying: {
+              baseAPR: 0.02,
+              rewardsAPR: 0.01,
+              estimatedAPR: 0.03,
+              estimatedAPY: 0.0305,
+              coveredDebtRatio: 0.5,
+            },
           },
           extra: {
             katanaAppRewardsAPR: 0.1234,
@@ -112,6 +129,12 @@ describe('/api/webhook route', () => {
     const body = await response.json()
 
     expect(response.status).toBe(200)
+    expect(body).not.toContainEqual(
+      expect.objectContaining({ component: 'morphoRewardsAPR' }),
+    )
+    expect(body).not.toContainEqual(
+      expect.objectContaining({ component: 'estimatedAPR' }),
+    )
     expect(body).toEqual([
       {
         chainId: 747474,

--- a/src/app/api/webhook/route.ts
+++ b/src/app/api/webhook/route.ts
@@ -99,20 +99,47 @@ function buildStrategyOutputs(
 ): KongOutput[] {
   return strategies.flatMap((strategy) => {
     const address = strategy.address
-    const value = toFiniteNumber(strategy.strategyRewardsAPR)
-
-    if (!address || value == null) {
+    if (!address) {
       return []
     }
 
-    return [
-      {
+    const outputs: KongOutput[] = []
+    const estimatedAPR = toFiniteNumber(
+      strategy.morphoUnderlyingAPR?.estimatedAPR,
+    )
+    const estimatedAPY = toFiniteNumber(
+      strategy.morphoUnderlyingAPR?.estimatedAPY,
+    )
+    const katRewardsAPR = toFiniteNumber(strategy.strategyRewardsAPR)
+
+    if (estimatedAPR != null) {
+      outputs.push({
+        ...base,
+        address,
+        component: 'netAPR',
+        value: estimatedAPR,
+      })
+    }
+
+    if (estimatedAPY != null) {
+      outputs.push({
+        ...base,
+        address,
+        component: 'netAPY',
+        value: estimatedAPY,
+      })
+    }
+
+    if (katRewardsAPR != null) {
+      outputs.push({
         ...base,
         address,
         component: STRATEGY_APR_COMPONENT,
-        value,
-      },
-    ]
+        value: katRewardsAPR,
+      })
+    }
+
+    return outputs
   })
 }
 

--- a/src/app/services/aprCalcs/morphoUnderlyingAprCalculator.test.ts
+++ b/src/app/services/aprCalcs/morphoUnderlyingAprCalculator.test.ts
@@ -125,7 +125,15 @@ describe('MorphoUnderlyingAprCalculator', () => {
       {
         strategyAddress: COMPOUNDER_ADDRESS,
         morphoVaultAddress: MORPHO_VAULT_ADDRESS,
+        morphoBaseAPR: 52 * ((1 + 0.052) ** (1 / 52) - 1),
+        morphoBaseAPY: 0.052,
+        morphoRewardsAPR: 0.01,
         replacementAPR: 52 * ((1 + 0.052) ** (1 / 52) - 1) + 0.01,
+        estimatedAPY:
+          (1 +
+            (52 * ((1 + 0.052) ** (1 / 52) - 1) + 0.01) / 52) **
+            52 -
+          1,
         usedMorphoApi: true,
       },
     ])
@@ -148,7 +156,11 @@ describe('MorphoUnderlyingAprCalculator', () => {
       {
         strategyAddress: COMPOUNDER_ADDRESS,
         morphoVaultAddress: MORPHO_VAULT_ADDRESS,
+        morphoBaseAPR: 0,
+        morphoBaseAPY: 0,
+        morphoRewardsAPR: 0,
         replacementAPR: 0.01,
+        estimatedAPY: (1 + 0.01 / 52) ** 52 - 1,
         usedMorphoApi: false,
       },
     ])

--- a/src/app/services/aprCalcs/morphoUnderlyingAprCalculator.ts
+++ b/src/app/services/aprCalcs/morphoUnderlyingAprCalculator.ts
@@ -7,7 +7,11 @@ import { YearnApiService } from '../externalApis/yearnApi'
 export interface MorphoUnderlyingAprResult {
   strategyAddress: string
   morphoVaultAddress: string | null
+  morphoBaseAPR: number
+  morphoBaseAPY: number
+  morphoRewardsAPR: number
   replacementAPR: number
+  estimatedAPY: number
   usedMorphoApi: boolean
 }
 
@@ -76,12 +80,14 @@ export class MorphoUnderlyingAprCalculator {
               ? morphoVaultEstimates[morphoVaultAddress.toLowerCase()]
               : undefined
 
+            const aprEstimate = estimate
+              ? this.buildMorphoAprEstimate(estimate)
+              : this.buildFallbackAprEstimate(strategy)
+
             return {
               strategyAddress,
               morphoVaultAddress,
-              replacementAPR: estimate
-                ? this.calculateReplacementAPR(estimate)
-                : this.getFallbackStrategyAPR(strategy),
+              ...aprEstimate,
               usedMorphoApi: Boolean(estimate),
             }
           })
@@ -125,14 +131,44 @@ export class MorphoUnderlyingAprCalculator {
     return this.morphoApi.getVaultAprEstimates(morphoVaultAddresses)
   }
 
-  private calculateReplacementAPR(
-    estimate: MorphoVaultAprEstimate,
-  ): number {
-    return this.convertApyToWeeklyApr(estimate.baseAPY) + estimate.rewardsAPR
+  private buildMorphoAprEstimate(estimate: MorphoVaultAprEstimate): Omit<
+    MorphoUnderlyingAprResult,
+    'strategyAddress' | 'morphoVaultAddress' | 'usedMorphoApi'
+  > {
+    const morphoBaseAPR = this.convertApyToWeeklyApr(estimate.baseAPY)
+    const morphoRewardsAPR = estimate.rewardsAPR
+    const replacementAPR = morphoBaseAPR + morphoRewardsAPR
+
+    return {
+      morphoBaseAPR,
+      morphoBaseAPY: estimate.baseAPY,
+      morphoRewardsAPR,
+      replacementAPR,
+      estimatedAPY: this.convertAprToWeeklyApy(replacementAPR),
+    }
+  }
+
+  private buildFallbackAprEstimate(strategy: YearnStrategy): Omit<
+    MorphoUnderlyingAprResult,
+    'strategyAddress' | 'morphoVaultAddress' | 'usedMorphoApi'
+  > {
+    const replacementAPR = this.getFallbackStrategyAPR(strategy)
+
+    return {
+      morphoBaseAPR: 0,
+      morphoBaseAPY: 0,
+      morphoRewardsAPR: 0,
+      replacementAPR,
+      estimatedAPY: this.convertAprToWeeklyApy(replacementAPR),
+    }
   }
 
   private convertApyToWeeklyApr(apy: number): number {
     return 52 * ((1 + apy) ** (1 / 52) - 1)
+  }
+
+  private convertAprToWeeklyApy(apr: number): number {
+    return (1 + apr / 52) ** 52 - 1
   }
 
   private getFallbackStrategyAPR(strategy: YearnStrategy): number {

--- a/src/app/services/dataCache.test.ts
+++ b/src/app/services/dataCache.test.ts
@@ -389,7 +389,11 @@ describe('DataCacheService.generateVaultAPRData', () => {
           strategyAddress: morphoStrategyAddress,
           morphoVaultAddress:
             '0x00000000000000000000000000000000000000a1',
+          morphoBaseAPR: 0.08,
+          morphoBaseAPY: 0.0832,
+          morphoRewardsAPR: 0.02,
           replacementAPR: 0.10,
+          estimatedAPY: (1 + 0.10 / 52) ** 52 - 1,
           usedMorphoApi: true,
         },
       ],
@@ -407,6 +411,23 @@ describe('DataCacheService.generateVaultAPRData', () => {
         (steerGross -
           Math.min(0.02 * 0.25 + steerGross * 0.1, steerGross * 0.5)),
     )
+    expect(data[vault.address].apr?.forwardAPR?.morphoUnderlying).toEqual({
+      baseAPR: 0.08 * 0.5,
+      rewardsAPR: 0.02 * 0.5,
+      estimatedAPR: 0.10 * 0.5,
+      estimatedAPY: (1 + (0.10 * 0.5) / 52) ** 52 - 1,
+      coveredDebtRatio: 0.5,
+    })
+    expect(data[vault.address].strategies[0].morphoUnderlyingAPR).toEqual({
+      morphoVaultAddress: '0x00000000000000000000000000000000000000a1',
+      usedMorphoApi: true,
+      morphoBaseAPR: 0.08,
+      morphoBaseAPY: 0.0832,
+      morphoRewardsAPR: 0.02,
+      estimatedAPR: 0.10,
+      estimatedAPY: (1 + 0.10 / 52) ** 52 - 1,
+    })
+    expect(data[vault.address].strategies[1].morphoUnderlyingAPR).toBeUndefined()
   })
 
   it('uses current strategy APR in forward APR when Morpho estimates are missing', async () => {
@@ -444,7 +465,11 @@ describe('DataCacheService.generateVaultAPRData', () => {
           strategyAddress: morphoStrategyAddress,
           morphoVaultAddress:
             '0x00000000000000000000000000000000000000a2',
+          morphoBaseAPR: 0,
+          morphoBaseAPY: 0,
+          morphoRewardsAPR: 0,
           replacementAPR: 0.03,
+          estimatedAPY: (1 + 0.03 / 52) ** 52 - 1,
           usedMorphoApi: false,
         },
       ],
@@ -455,6 +480,13 @@ describe('DataCacheService.generateVaultAPRData', () => {
 
     expect(data[vault.address].apr?.netAPR).toBe(0.02)
     expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(0.015)
+    expect(data[vault.address].apr?.forwardAPR?.morphoUnderlying).toEqual({
+      baseAPR: 0,
+      rewardsAPR: 0,
+      estimatedAPR: 0.015,
+      estimatedAPY: (1 + 0.015 / 52) ** 52 - 1,
+      coveredDebtRatio: 0.5,
+    })
   })
 
   it('keeps forward APR unchanged when there are no Morpho replacement results', async () => {

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -182,11 +182,17 @@ export class DataCacheService {
     const strategyRewardsByAddress = this.buildStrategyRewardsByAddress(
       strategyResults,
     )
+    const morphoUnderlyingByAddress = this.buildMorphoUnderlyingByAddress(
+      morphoUnderlyingResults,
+    )
 
     const strategiesWithRewards = (vault.strategies || []).map((strategy) => {
       const strategyAddress = this.normalizeAddress(strategy.address)
       const strategyRewards = strategyAddress
         ? strategyRewardsByAddress[strategyAddress]
+        : undefined
+      const morphoUnderlying = strategyAddress
+        ? morphoUnderlyingByAddress[strategyAddress]
         : undefined
       const strategyRewardsAPR = strategyRewards
         ? strategyRewards.rawApr > 0
@@ -196,6 +202,19 @@ export class DataCacheService {
 
       return {
         ...strategy,
+        ...(morphoUnderlying
+          ? {
+              morphoUnderlyingAPR: {
+                morphoVaultAddress: morphoUnderlying.morphoVaultAddress,
+                usedMorphoApi: morphoUnderlying.usedMorphoApi,
+                morphoBaseAPR: morphoUnderlying.morphoBaseAPR,
+                morphoBaseAPY: morphoUnderlying.morphoBaseAPY,
+                morphoRewardsAPR: morphoUnderlying.morphoRewardsAPR,
+                estimatedAPR: morphoUnderlying.replacementAPR,
+                estimatedAPY: morphoUnderlying.estimatedAPY,
+              },
+            }
+          : {}),
         ...(strategyRewards
           ? {
               strategyRewardsAPR,
@@ -312,6 +331,50 @@ export class DataCacheService {
         cvxAPR: null,
         rewardsAPR: null,
       },
+      morphoUnderlying: this.buildVaultMorphoUnderlyingAPR(
+        vault,
+        morphoUnderlyingResults,
+      ),
+    }
+  }
+
+  private buildVaultMorphoUnderlyingAPR(
+    vault: YearnVault,
+    morphoUnderlyingResults: MorphoUnderlyingAprResult[],
+  ): NonNullable<YearnVaultAPY['forwardAPR']>['morphoUnderlying'] {
+    const weighted = morphoUnderlyingResults.reduce(
+      (accumulator, result) => {
+        const strategy = vault.strategies.find(
+          (candidate) =>
+            candidate.address.toLowerCase() ===
+            result.strategyAddress.toLowerCase(),
+        )
+        if (!strategy) {
+          return accumulator
+        }
+
+        const debtShare = this.getStrategyDebtShare(strategy, vault)
+        if (debtShare <= 0) {
+          return accumulator
+        }
+
+        accumulator.baseAPR += result.morphoBaseAPR * debtShare
+        accumulator.rewardsAPR += result.morphoRewardsAPR * debtShare
+        accumulator.estimatedAPR += result.replacementAPR * debtShare
+        accumulator.coveredDebtRatio += debtShare
+        return accumulator
+      },
+      {
+        baseAPR: 0,
+        rewardsAPR: 0,
+        estimatedAPR: 0,
+        coveredDebtRatio: 0,
+      },
+    )
+
+    return {
+      ...weighted,
+      estimatedAPY: this.convertAprToWeeklyApy(weighted.estimatedAPR),
     }
   }
 
@@ -404,6 +467,17 @@ export class DataCacheService {
     )
   }
 
+  private buildMorphoUnderlyingByAddress(
+    results: MorphoUnderlyingAprResult[],
+  ): Record<string, MorphoUnderlyingAprResult> {
+    return Object.fromEntries(
+      results.map((result) => [
+        result.strategyAddress.toLowerCase(),
+        result,
+      ]),
+    )
+  }
+
   private hasResolvedRewardToken(result: RewardCalculatorResult): boolean {
     return Boolean(result.breakdown?.token?.address)
   }
@@ -424,5 +498,9 @@ export class DataCacheService {
   private toFiniteNumber(value?: number | string): number {
     const parsed = Number(value)
     return Number.isFinite(parsed) ? parsed : 0
+  }
+
+  private convertAprToWeeklyApy(apr: number): number {
+    return (1 + apr / 52) ** 52 - 1
   }
 }

--- a/src/app/types/yearn.ts
+++ b/src/app/types/yearn.ts
@@ -14,12 +14,31 @@ export interface YearnRewardToken {
   assumedFDV?: number
 }
 
+export interface MorphoUnderlyingAPR {
+  morphoVaultAddress: string | null
+  usedMorphoApi: boolean
+  morphoBaseAPR: number
+  morphoBaseAPY: number
+  morphoRewardsAPR: number
+  estimatedAPR: number
+  estimatedAPY: number
+}
+
+export interface VaultMorphoUnderlyingAPR {
+  baseAPR: number
+  rewardsAPR: number
+  estimatedAPR: number
+  estimatedAPY: number
+  coveredDebtRatio: number
+}
+
 export interface YearnStrategy {
   address: string
   name: string
   status?: string
   netAPR?: number | null
   strategyRewardsAPR?: number | null
+  morphoUnderlyingAPR?: MorphoUnderlyingAPR
   rewardToken?: YearnRewardToken | null
   underlyingContract?: string | null
   details?: YearnStrategyDetails
@@ -73,6 +92,7 @@ export interface YearnVaultAPY {
       cvxAPR: number | null
       rewardsAPR: number | null
     }
+    morphoUnderlying?: VaultMorphoUnderlyingAPR
   }
 }
 


### PR DESCRIPTION
## Summary

- expose Morpho base yield, reward APR, estimated APR/APY, and coverage diagnostics at strategy and vault levels. These fields are not passed to Kong and can be used to troubleshoot and better understand reward flows.
- emit strategy-addressed `netAPR` and `netAPY` webhook rows alongside `katRewardsAPR`. These are passed to Kong so that strategy APYs can correctly show compounding Morpho rewards 

## Why

Morpho V2 compoundable rewards were included in the allocator vault forward APR, but Kong strategy composition entries only received the KAT reward component. As a result, `composition[].performance.estimated.apr` and `.apy` did not exist or did not include the underlying Morpho base yield and non-KAT rewards.

This sends the existing Morpho strategy estimates using the Kong fields already used for estimated strategy performance while keeping KAT rewards separate.

## User impact

Kong can populate estimated APR and APY for Morpho strategies, allowing yearn.fi strategy displays to include compoundable Morpho rewards. The additional diagnostics also make upstream APR composition visible in the service response.

## Testing

- `bun run test:run` — 68 tests passed
- `bun run lint` — no warnings or errors
- `bun run build` — production build passed