### PR TITLE
fix: calculate unallocated Morpho strategy APYs

### DIFF
--- a/src/app/api/webhook/route.test.ts
+++ b/src/app/api/webhook/route.test.ts
@@ -254,6 +254,7 @@ describe('/api/webhook route', () => {
           {
             address: zeroEstimateAddress,
             name: 'Morpho Strategy Without KAT',
+            status: 'unallocated',
             morphoUnderlyingAPR: {
               morphoVaultAddress:
                 '0x00000000000000000000000000000000000000e1',

--- a/src/app/services/aprCalcs/morphoUnderlyingAprCalculator.test.ts
+++ b/src/app/services/aprCalcs/morphoUnderlyingAprCalculator.test.ts
@@ -2,15 +2,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { YearnVault } from '../../types'
 
 const mocks = vi.hoisted(() => ({
-  getActiveMorphoCompounderStrategies: vi.fn(),
+  getMorphoCompounderStrategies: vi.fn(),
   getMorphoVaultsFromStrategies: vi.fn(),
   getVaultAprEstimates: vi.fn(),
 }))
 
 vi.mock('../externalApis/yearnApi', () => ({
   YearnApiService: vi.fn().mockImplementation(() => ({
-    getActiveMorphoCompounderStrategies:
-      mocks.getActiveMorphoCompounderStrategies,
+    getMorphoCompounderStrategies: mocks.getMorphoCompounderStrategies,
   })),
 }))
 
@@ -89,14 +88,14 @@ const makeVault = (): YearnVault => ({
 
 describe('MorphoUnderlyingAprCalculator', () => {
   beforeEach(() => {
-    mocks.getActiveMorphoCompounderStrategies.mockReset()
+    mocks.getMorphoCompounderStrategies.mockReset()
     mocks.getMorphoVaultsFromStrategies.mockReset()
     mocks.getVaultAprEstimates.mockReset()
   })
 
-  it('uses dynamic vault mapping for selected active compounders only', async () => {
+  it('uses dynamic vault mapping for selected compounders', async () => {
     const vault = makeVault()
-    mocks.getActiveMorphoCompounderStrategies.mockReturnValue([
+    mocks.getMorphoCompounderStrategies.mockReturnValue([
       COMPOUNDER_ADDRESS,
     ])
     mocks.getMorphoVaultsFromStrategies.mockResolvedValue({
@@ -112,9 +111,7 @@ describe('MorphoUnderlyingAprCalculator', () => {
     const calculator = new MorphoUnderlyingAprCalculator()
     const results = await calculator.calculateVaultAPRs([vault])
 
-    expect(mocks.getActiveMorphoCompounderStrategies).toHaveBeenCalledWith(
-      vault,
-    )
+    expect(mocks.getMorphoCompounderStrategies).toHaveBeenCalledWith(vault)
     expect(mocks.getMorphoVaultsFromStrategies).toHaveBeenCalledWith([
       COMPOUNDER_ADDRESS,
     ])
@@ -141,7 +138,7 @@ describe('MorphoUnderlyingAprCalculator', () => {
 
   it('falls back to the existing strategy APR when an estimate is missing', async () => {
     const vault = makeVault()
-    mocks.getActiveMorphoCompounderStrategies.mockReturnValue([
+    mocks.getMorphoCompounderStrategies.mockReturnValue([
       COMPOUNDER_ADDRESS,
     ])
     mocks.getMorphoVaultsFromStrategies.mockResolvedValue({

--- a/src/app/services/aprCalcs/morphoUnderlyingAprCalculator.ts
+++ b/src/app/services/aprCalcs/morphoUnderlyingAprCalculator.ts
@@ -33,7 +33,7 @@ export class MorphoUnderlyingAprCalculator {
       .map((vault) => ({
         vault,
         strategyAddresses:
-          this.yearnApi.getActiveMorphoCompounderStrategies(vault),
+          this.yearnApi.getMorphoCompounderStrategies(vault),
       }))
       .filter(({ strategyAddresses }) => strategyAddresses.length > 0)
 

--- a/src/app/services/dataCache.test.ts
+++ b/src/app/services/dataCache.test.ts
@@ -370,7 +370,7 @@ describe('DataCacheService.generateVaultAPRData', () => {
         },
         {
           address: idleStrategyAddress,
-          name: 'Idle Slot',
+          name: 'Morpho Idle USDC Compounder',
           status: 'unallocated',
           netAPR: 0.50,
           details: {
@@ -394,6 +394,17 @@ describe('DataCacheService.generateVaultAPRData', () => {
           morphoRewardsAPR: 0.02,
           replacementAPR: 0.10,
           estimatedAPY: (1 + 0.10 / 52) ** 52 - 1,
+          usedMorphoApi: true,
+        },
+        {
+          strategyAddress: idleStrategyAddress,
+          morphoVaultAddress:
+            '0x00000000000000000000000000000000000000a2',
+          morphoBaseAPR: 0.20,
+          morphoBaseAPY: 0.22,
+          morphoRewardsAPR: 0.30,
+          replacementAPR: 0.50,
+          estimatedAPY: (1 + 0.50 / 52) ** 52 - 1,
           usedMorphoApi: true,
         },
       ],
@@ -428,6 +439,15 @@ describe('DataCacheService.generateVaultAPRData', () => {
       estimatedAPY: (1 + 0.10 / 52) ** 52 - 1,
     })
     expect(data[vault.address].strategies[1].morphoUnderlyingAPR).toBeUndefined()
+    expect(data[vault.address].strategies[2].morphoUnderlyingAPR).toEqual({
+      morphoVaultAddress: '0x00000000000000000000000000000000000000a2',
+      usedMorphoApi: true,
+      morphoBaseAPR: 0.20,
+      morphoBaseAPY: 0.22,
+      morphoRewardsAPR: 0.30,
+      estimatedAPR: 0.50,
+      estimatedAPY: (1 + 0.50 / 52) ** 52 - 1,
+    })
   })
 
   it('uses current strategy APR in forward APR when Morpho estimates are missing', async () => {

--- a/src/app/services/externalApis/yearnApi.test.ts
+++ b/src/app/services/externalApis/yearnApi.test.ts
@@ -159,7 +159,7 @@ describe('YearnApiService', () => {
     )
   })
 
-  it('selects active Morpho compounders only for replacement APRs', () => {
+  it('selects allocated and unallocated Morpho compounders for estimates', () => {
     const vault: YearnVault = {
       address: '0x00000000000000000000000000000000000000aa',
       symbol: 'yvvbUSDC',
@@ -214,8 +214,9 @@ describe('YearnApiService', () => {
 
     const service = new YearnApiService()
 
-    expect(service.getActiveMorphoCompounderStrategies(vault)).toEqual([
+    expect(service.getMorphoCompounderStrategies(vault)).toEqual([
       '0x0000000000000000000000000000000000000001',
+      '0x0000000000000000000000000000000000000003',
     ])
   })
 })

--- a/src/app/services/externalApis/yearnApi.ts
+++ b/src/app/services/externalApis/yearnApi.ts
@@ -431,16 +431,13 @@ export class YearnApiService {
       .map((strategy): string => strategy.address)
   }
 
-  getActiveMorphoCompounderStrategies(vault: YearnVault): string[] {
+  getMorphoCompounderStrategies(vault: YearnVault): string[] {
     return vault.strategies
       .filter((strategy): boolean =>
         Boolean(
           strategy.name?.includes('Morpho') &&
             strategy.name?.includes('Compounder') &&
-            !strategy.name?.includes('Lender Borrower') &&
-            strategy.details?.totalDebt &&
-            strategy.details.totalDebt !== '0' &&
-            strategy.details.totalDebt !== '0x0'
+            !strategy.name?.includes('Lender Borrower')
         )
       )
       .map((strategy): string => strategy.address)


### PR DESCRIPTION
## Summary

- query underlying Morpho vault estimates for allocated and unallocated compounder strategies
- attach complete base, rewards, estimated APR, and estimated APY diagnostics to zero-debt strategies
- continue excluding zero-debt strategies from parent allocator APR weighting
- pass the resulting strategy estimates through the existing Kong `netAPR` and `netAPY` webhook rows

## Why

Morpho compounders were previously selected only when they had nonzero debt. Unallocated strategies therefore had no forward-looking estimate, even though their underlying Morpho vaults still exposed current base yield and reward rates.

Strategy opportunity APY should remain available independently of allocation. Allocation should affect only how much the strategy contributes to the parent vault estimate.

This change means that kong will show correct APYs for unallocated katana strategies, which can then be displayed correctly on yearn.fi.

## User impact

Kong can populate `composition[].performance.estimated.apr` and `.apy` for unallocated Morpho compounders. Parent vault estimates remain unchanged because zero-debt strategies retain a zero weighting.

## Validation

- `bun run test:run` — 68 tests passed
- `bun run lint` — no warnings or errors
- `bun run build` — production build passed
- live preview found 8 unallocated Morpho compounders and populated estimates for all 8