### PR TITLE
Fix forward APR fallback handling

### DIFF
--- a/docs/api-integration-guide.md
+++ b/docs/api-integration-guide.md
@@ -190,6 +190,7 @@ APR units:
 `DataCacheService.aggregateVaultResults()` sets:
 
 - `strategies[].strategyRewardsAPR` for active Morpho/Steer strategies as raw strategy APR in decimal form
+- `strategies[].netAPR` from a successful live underlying APR estimate, or `null` when no live estimate is available; Kong `latestReportApr` is historical and is never exposed as a current strategy APR
 - `strategies[].rewardToken` and `strategies[].underlyingContract` when the strategy pool/token could be resolved
 - `apr.extra.katanaRewardsAPR` (legacy alias)
 - `apr.extra.katanaAppRewardsAPR` from Yearn vault-level rewards

--- a/docs/api-integration-guide.md
+++ b/docs/api-integration-guide.md
@@ -190,7 +190,7 @@ APR units:
 `DataCacheService.aggregateVaultResults()` sets:
 
 - `strategies[].strategyRewardsAPR` for active Morpho/Steer strategies as raw strategy APR in decimal form
-- `strategies[].netAPR` from a successful live underlying APR estimate, or `null` when no live estimate is available; Kong `latestReportApr` is historical and is never exposed as a current strategy APR
+- `strategies[].netAPR` from a successful live Morpho replacement when available, otherwise from Kong's on-chain oracle APR (including `0`); Kong `latestReportApr` is historical and is never exposed as a current strategy APR
 - `strategies[].rewardToken` and `strategies[].underlyingContract` when the strategy pool/token could be resolved
 - `apr.extra.katanaRewardsAPR` (legacy alias)
 - `apr.extra.katanaAppRewardsAPR` from Yearn vault-level rewards

--- a/src/app/services/aprCalcs/morphoUnderlyingAprCalculator.test.ts
+++ b/src/app/services/aprCalcs/morphoUnderlyingAprCalculator.test.ts
@@ -136,7 +136,7 @@ describe('MorphoUnderlyingAprCalculator', () => {
     ])
   })
 
-  it('falls back to the existing strategy APR when an estimate is missing', async () => {
+  it('marks the forward estimate unavailable when the Morpho estimate is missing', async () => {
     const vault = makeVault()
     mocks.getMorphoCompounderStrategies.mockReturnValue([
       COMPOUNDER_ADDRESS,
@@ -156,8 +156,8 @@ describe('MorphoUnderlyingAprCalculator', () => {
         morphoBaseAPR: 0,
         morphoBaseAPY: 0,
         morphoRewardsAPR: 0,
-        replacementAPR: 0.01,
-        estimatedAPY: (1 + 0.01 / 52) ** 52 - 1,
+        replacementAPR: null,
+        estimatedAPY: null,
         usedMorphoApi: false,
       },
     ])

--- a/src/app/services/aprCalcs/morphoUnderlyingAprCalculator.ts
+++ b/src/app/services/aprCalcs/morphoUnderlyingAprCalculator.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import type { YearnVault, YearnStrategy } from '../../types'
+import type { YearnVault } from '../../types'
 import { ContractReaderService } from '../contractReader'
 import { MorphoApiService, type MorphoVaultAprEstimate } from '../externalApis/morphoApi'
 import { YearnApiService } from '../externalApis/yearnApi'
@@ -10,8 +10,8 @@ export interface MorphoUnderlyingAprResult {
   morphoBaseAPR: number
   morphoBaseAPY: number
   morphoRewardsAPR: number
-  replacementAPR: number
-  estimatedAPY: number
+  replacementAPR: number | null
+  estimatedAPY: number | null
   usedMorphoApi: boolean
 }
 
@@ -82,7 +82,7 @@ export class MorphoUnderlyingAprCalculator {
 
             const aprEstimate = estimate
               ? this.buildMorphoAprEstimate(estimate)
-              : this.buildFallbackAprEstimate(strategy)
+              : this.buildUnavailableAprEstimate()
 
             return {
               strategyAddress,
@@ -148,18 +148,16 @@ export class MorphoUnderlyingAprCalculator {
     }
   }
 
-  private buildFallbackAprEstimate(strategy: YearnStrategy): Omit<
+  private buildUnavailableAprEstimate(): Omit<
     MorphoUnderlyingAprResult,
     'strategyAddress' | 'morphoVaultAddress' | 'usedMorphoApi'
   > {
-    const replacementAPR = this.getFallbackStrategyAPR(strategy)
-
     return {
       morphoBaseAPR: 0,
       morphoBaseAPY: 0,
       morphoRewardsAPR: 0,
-      replacementAPR,
-      estimatedAPY: this.convertAprToWeeklyApy(replacementAPR),
+      replacementAPR: null,
+      estimatedAPY: null,
     }
   }
 
@@ -169,10 +167,5 @@ export class MorphoUnderlyingAprCalculator {
 
   private convertAprToWeeklyApy(apr: number): number {
     return (1 + apr / 52) ** 52 - 1
-  }
-
-  private getFallbackStrategyAPR(strategy: YearnStrategy): number {
-    const parsed = Number(strategy.netAPR)
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
   }
 }

--- a/src/app/services/dataCache.test.ts
+++ b/src/app/services/dataCache.test.ts
@@ -309,7 +309,7 @@ describe('DataCacheService.generateVaultAPRData', () => {
     expect(data[vault.address].apr?.extra?.katanaRewardsAPR).toBe(0)
   })
 
-  it('preserves the existing forward APR when an allocated strategy lacks a live replacement', async () => {
+  it('uses a zero Kong oracle APR when an allocated strategy lacks a Morpho replacement', async () => {
     const morphoStrategyAddress =
       '0x00000000000000000000000000000000000000f1'
     const steerStrategyAddress =
@@ -359,7 +359,7 @@ describe('DataCacheService.generateVaultAPRData', () => {
           address: steerStrategyAddress,
           name: 'Steer USDC Strategy',
           status: 'active',
-          netAPR: 0.04,
+          netAPR: 0,
           details: {
             totalDebt: '25',
             totalGain: '0',
@@ -412,11 +412,21 @@ describe('DataCacheService.generateVaultAPRData', () => {
 
     const service = new DataCacheService()
     const data = await service.generateVaultAPRData()
+    const morphoGross = 0.10 * 0.5
+
     expect(data[vault.address].apr?.netAPR).toBe(0.0123)
-    expect(data[vault.address].apr?.forwardAPR?.netAPR).toBe(0.025)
-    expect(data[vault.address].apr?.forwardAPR?.morphoUnderlying).toBeUndefined()
+    expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(
+      morphoGross - (0.02 * 0.5 + morphoGross * 0.1),
+    )
+    expect(data[vault.address].apr?.forwardAPR?.morphoUnderlying).toEqual({
+      baseAPR: 0.08 * 0.5,
+      rewardsAPR: 0.02 * 0.5,
+      estimatedAPR: 0.10 * 0.5,
+      estimatedAPY: (1 + (0.10 * 0.5) / 52) ** 52 - 1,
+      coveredDebtRatio: 0.5,
+    })
     expect(data[vault.address].strategies[0].netAPR).toBe(0.10)
-    expect(data[vault.address].strategies[1].netAPR).toBeNull()
+    expect(data[vault.address].strategies[1].netAPR).toBe(0)
     expect(data[vault.address].strategies[2].netAPR).toBe(0.50)
     expect(data[vault.address].strategies[0].morphoUnderlyingAPR).toEqual({
       morphoVaultAddress: '0x00000000000000000000000000000000000000a1',
@@ -439,7 +449,7 @@ describe('DataCacheService.generateVaultAPRData', () => {
     })
   })
 
-  it('does not use historical strategy APR when a Morpho estimate fails', async () => {
+  it('uses the Kong oracle APR when a Morpho estimate fails', async () => {
     const morphoStrategyAddress =
       '0x00000000000000000000000000000000000000f4'
     const vault = makeVault({
@@ -488,8 +498,8 @@ describe('DataCacheService.generateVaultAPRData', () => {
     const data = await service.generateVaultAPRData()
 
     expect(data[vault.address].apr?.netAPR).toBe(0.02)
-    expect(data[vault.address].apr?.forwardAPR).toBeUndefined()
-    expect(data[vault.address].strategies[0].netAPR).toBeNull()
+    expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(0.015)
+    expect(data[vault.address].strategies[0].netAPR).toBe(0.03)
     expect(data[vault.address].strategies[0].morphoUnderlyingAPR).toMatchObject({
       usedMorphoApi: false,
       estimatedAPR: null,

--- a/src/app/services/dataCache.test.ts
+++ b/src/app/services/dataCache.test.ts
@@ -309,7 +309,7 @@ describe('DataCacheService.generateVaultAPRData', () => {
     expect(data[vault.address].apr?.extra?.katanaRewardsAPR).toBe(0)
   })
 
-  it('weights Morpho replacement APR with unchanged strategy sources and idle assets', async () => {
+  it('preserves the existing forward APR when an allocated strategy lacks a live replacement', async () => {
     const morphoStrategyAddress =
       '0x00000000000000000000000000000000000000f1'
     const steerStrategyAddress =
@@ -325,7 +325,7 @@ describe('DataCacheService.generateVaultAPRData', () => {
         },
         forwardAPR: {
           type: '',
-          netAPR: null,
+          netAPR: 0.025,
           composite: {
             boost: null,
             poolAPY: null,
@@ -412,23 +412,12 @@ describe('DataCacheService.generateVaultAPRData', () => {
 
     const service = new DataCacheService()
     const data = await service.generateVaultAPRData()
-    const morphoGross = 0.10 * 0.5
-    const steerGross = 0.04 * 0.25
-
     expect(data[vault.address].apr?.netAPR).toBe(0.0123)
-    expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(
-      morphoGross -
-        (0.02 * 0.5 + morphoGross * 0.1) +
-        (steerGross -
-          Math.min(0.02 * 0.25 + steerGross * 0.1, steerGross * 0.5)),
-    )
-    expect(data[vault.address].apr?.forwardAPR?.morphoUnderlying).toEqual({
-      baseAPR: 0.08 * 0.5,
-      rewardsAPR: 0.02 * 0.5,
-      estimatedAPR: 0.10 * 0.5,
-      estimatedAPY: (1 + (0.10 * 0.5) / 52) ** 52 - 1,
-      coveredDebtRatio: 0.5,
-    })
+    expect(data[vault.address].apr?.forwardAPR?.netAPR).toBe(0.025)
+    expect(data[vault.address].apr?.forwardAPR?.morphoUnderlying).toBeUndefined()
+    expect(data[vault.address].strategies[0].netAPR).toBe(0.10)
+    expect(data[vault.address].strategies[1].netAPR).toBeNull()
+    expect(data[vault.address].strategies[2].netAPR).toBe(0.50)
     expect(data[vault.address].strategies[0].morphoUnderlyingAPR).toEqual({
       morphoVaultAddress: '0x00000000000000000000000000000000000000a1',
       usedMorphoApi: true,
@@ -450,7 +439,7 @@ describe('DataCacheService.generateVaultAPRData', () => {
     })
   })
 
-  it('uses current strategy APR in forward APR when Morpho estimates are missing', async () => {
+  it('does not use historical strategy APR when a Morpho estimate fails', async () => {
     const morphoStrategyAddress =
       '0x00000000000000000000000000000000000000f4'
     const vault = makeVault({
@@ -488,8 +477,8 @@ describe('DataCacheService.generateVaultAPRData', () => {
           morphoBaseAPR: 0,
           morphoBaseAPY: 0,
           morphoRewardsAPR: 0,
-          replacementAPR: 0.03,
-          estimatedAPY: (1 + 0.03 / 52) ** 52 - 1,
+          replacementAPR: null,
+          estimatedAPY: null,
           usedMorphoApi: false,
         },
       ],
@@ -499,13 +488,12 @@ describe('DataCacheService.generateVaultAPRData', () => {
     const data = await service.generateVaultAPRData()
 
     expect(data[vault.address].apr?.netAPR).toBe(0.02)
-    expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(0.015)
-    expect(data[vault.address].apr?.forwardAPR?.morphoUnderlying).toEqual({
-      baseAPR: 0,
-      rewardsAPR: 0,
-      estimatedAPR: 0.015,
-      estimatedAPY: (1 + 0.015 / 52) ** 52 - 1,
-      coveredDebtRatio: 0.5,
+    expect(data[vault.address].apr?.forwardAPR).toBeUndefined()
+    expect(data[vault.address].strategies[0].netAPR).toBeNull()
+    expect(data[vault.address].strategies[0].morphoUnderlyingAPR).toMatchObject({
+      usedMorphoApi: false,
+      estimatedAPR: null,
+      estimatedAPY: null,
     })
   })
 

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -199,9 +199,14 @@ export class DataCacheService {
           ? strategyRewards.rawApr
           : strategy.strategyRewardsAPR ?? strategyRewards.rawApr
         : strategy.strategyRewardsAPR ?? null
+      const liveStrategyNetAPR =
+        morphoUnderlying && this.hasLiveMorphoReplacement(morphoUnderlying)
+          ? morphoUnderlying.replacementAPR
+          : null
 
       return {
         ...strategy,
+        netAPR: liveStrategyNetAPR,
         ...(morphoUnderlying
           ? {
               morphoUnderlyingAPR: {
@@ -296,27 +301,38 @@ export class DataCacheService {
       return vault.apr?.forwardAPR
     }
 
+    const liveResults = morphoUnderlyingResults.filter(
+      this.hasLiveMorphoReplacement,
+    )
     const replacementAprByStrategy = new Map(
-      morphoUnderlyingResults.map((result) => [
+      liveResults.map((result) => [
         result.strategyAddress.toLowerCase(),
         result.replacementAPR,
       ]),
     )
+    const allocatedStrategies = (vault.strategies || [])
+      .map((strategy) => ({
+        strategy,
+        debtShare: this.getStrategyDebtShare(strategy, vault),
+      }))
+      .filter(({ debtShare }) => debtShare > 0)
 
-    const netAPR = (vault.strategies || []).reduce((sum, strategy) => {
-      const debtShare = this.getStrategyDebtShare(strategy, vault)
-      if (debtShare <= 0) {
-        return sum
-      }
+    const hasCompleteLiveCoverage = allocatedStrategies.every(({ strategy }) =>
+      replacementAprByStrategy.has(strategy.address.toLowerCase()),
+    )
+    // Never fill partial live coverage with Kong's historical latestReportApr.
+    if (!hasCompleteLiveCoverage) {
+      return vault.apr?.forwardAPR
+    }
 
+    const netAPR = allocatedStrategies.reduce((sum, { strategy, debtShare }) => {
       const replacementAPR = replacementAprByStrategy.get(
         strategy.address.toLowerCase(),
-      )
-      const strategyAPR =
-        replacementAPR ?? this.getCurrentStrategyAPR(strategy)
+      )!
 
       return (
-        sum + this.computeNetStrategyForwardAPR(strategyAPR, debtShare, vault)
+        sum +
+        this.computeNetStrategyForwardAPR(replacementAPR, debtShare, vault)
       )
     }, 0)
 
@@ -333,14 +349,16 @@ export class DataCacheService {
       },
       morphoUnderlying: this.buildVaultMorphoUnderlyingAPR(
         vault,
-        morphoUnderlyingResults,
+        liveResults,
       ),
     }
   }
 
   private buildVaultMorphoUnderlyingAPR(
     vault: YearnVault,
-    morphoUnderlyingResults: MorphoUnderlyingAprResult[],
+    morphoUnderlyingResults: Array<
+      MorphoUnderlyingAprResult & { replacementAPR: number }
+    >,
   ): NonNullable<YearnVaultAPY['forwardAPR']>['morphoUnderlying'] {
     const weighted = morphoUnderlyingResults.reduce(
       (accumulator, result) => {
@@ -434,9 +452,16 @@ export class DataCacheService {
     }
   }
 
-  private getCurrentStrategyAPR(strategy: YearnStrategy): number {
-    const parsed = this.toFiniteNumber(strategy.netAPR ?? undefined)
-    return parsed > 0 ? parsed : 0
+  private hasLiveMorphoReplacement(
+    result: MorphoUnderlyingAprResult,
+  ): result is MorphoUnderlyingAprResult & {
+    replacementAPR: number
+  } {
+    return (
+      result.usedMorphoApi &&
+      typeof result.replacementAPR === 'number' &&
+      Number.isFinite(result.replacementAPR)
+    )
   }
 
   private buildStrategyRewardsByAddress(

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -202,7 +202,7 @@ export class DataCacheService {
       const liveStrategyNetAPR =
         morphoUnderlying && this.hasLiveMorphoReplacement(morphoUnderlying)
           ? morphoUnderlying.replacementAPR
-          : null
+          : this.getKongOracleAPR(strategy)
 
       return {
         ...strategy,
@@ -301,11 +301,11 @@ export class DataCacheService {
       return vault.apr?.forwardAPR
     }
 
-    const liveResults = morphoUnderlyingResults.filter(
+    const liveMorphoResults = morphoUnderlyingResults.filter(
       this.hasLiveMorphoReplacement,
     )
-    const replacementAprByStrategy = new Map(
-      liveResults.map((result) => [
+    const morphoReplacementByStrategy = new Map(
+      liveMorphoResults.map((result) => [
         result.strategyAddress.toLowerCase(),
         result.replacementAPR,
       ]),
@@ -317,22 +317,28 @@ export class DataCacheService {
       }))
       .filter(({ debtShare }) => debtShare > 0)
 
-    const hasCompleteLiveCoverage = allocatedStrategies.every(({ strategy }) =>
-      replacementAprByStrategy.has(strategy.address.toLowerCase()),
+    const strategiesWithForwardAPR = allocatedStrategies.map((allocation) => ({
+      ...allocation,
+      forwardAPR:
+        morphoReplacementByStrategy.get(
+          allocation.strategy.address.toLowerCase(),
+        ) ?? this.getKongOracleAPR(allocation.strategy),
+    }))
+    const hasCompleteForwardCoverage = strategiesWithForwardAPR.every(
+      ({ forwardAPR }) => forwardAPR !== null,
     )
-    // Never fill partial live coverage with Kong's historical latestReportApr.
-    if (!hasCompleteLiveCoverage) {
+    if (!hasCompleteForwardCoverage) {
       return vault.apr?.forwardAPR
     }
 
-    const netAPR = allocatedStrategies.reduce((sum, { strategy, debtShare }) => {
-      const replacementAPR = replacementAprByStrategy.get(
-        strategy.address.toLowerCase(),
-      )!
-
+    const netAPR = strategiesWithForwardAPR.reduce((sum, allocation) => {
       return (
         sum +
-        this.computeNetStrategyForwardAPR(replacementAPR, debtShare, vault)
+        this.computeNetStrategyForwardAPR(
+          allocation.forwardAPR!,
+          allocation.debtShare,
+          vault,
+        )
       )
     }, 0)
 
@@ -349,7 +355,7 @@ export class DataCacheService {
       },
       morphoUnderlying: this.buildVaultMorphoUnderlyingAPR(
         vault,
-        liveResults,
+        liveMorphoResults,
       ),
     }
   }
@@ -462,6 +468,12 @@ export class DataCacheService {
       typeof result.replacementAPR === 'number' &&
       Number.isFinite(result.replacementAPR)
     )
+  }
+
+  private getKongOracleAPR(strategy: YearnStrategy): number | null {
+    return typeof strategy.netAPR === 'number' && Number.isFinite(strategy.netAPR)
+      ? strategy.netAPR
+      : null
   }
 
   private buildStrategyRewardsByAddress(

--- a/src/app/services/externalApis/yearnApi.test.ts
+++ b/src/app/services/externalApis/yearnApi.test.ts
@@ -94,6 +94,12 @@ describe('YearnApiService', () => {
               totalLoss: '1',
               lastReport: '123',
               latestReportApr: 0.75,
+              performance: {
+                oracle: {
+                  apr: 0,
+                  apy: 0,
+                },
+              },
               performanceFee: '0',
             },
           ],
@@ -137,7 +143,7 @@ describe('YearnApiService', () => {
         address: '0x00000000000000000000000000000000000000dd',
         name: 'Morpho Strategy',
         status: 'active',
-        netAPR: null,
+        netAPR: 0,
         strategyRewardsAPR: null,
         rewardToken: null,
         underlyingContract: null,

--- a/src/app/services/externalApis/yearnApi.test.ts
+++ b/src/app/services/externalApis/yearnApi.test.ts
@@ -93,6 +93,7 @@ describe('YearnApiService', () => {
               totalGain: '2',
               totalLoss: '1',
               lastReport: '123',
+              latestReportApr: 0.75,
               performanceFee: '0',
             },
           ],

--- a/src/app/services/externalApis/yearnApi.ts
+++ b/src/app/services/externalApis/yearnApi.ts
@@ -29,6 +29,10 @@ type KongVaultCompositionItem = {
   lastReport?: string | number
   performanceFee?: string | number
   performance?: {
+    oracle?: {
+      apr?: number | null
+      apy?: number | null
+    }
     estimated?: {
       components?: Record<string, number | string | null>
     }
@@ -208,9 +212,9 @@ const mapKongCompositionToYearnStrategy = (
     address: strategy.address,
     name: strategy.name || 'Unknown',
     status: totalDebt === '0' ? 'unallocated' : strategy.status,
-    // latestReportApr is a historical point-in-time measurement and parent
-    // composition snapshots can retain it after the strategy snapshot changes.
-    netAPR: null,
+    // Use Kong's on-chain APR oracle output, including a valid zero. Do not use
+    // latestReportApr, which is historical and can be stale in compositions.
+    netAPR: toFiniteNumberOrNull(strategy.performance?.oracle?.apr),
     strategyRewardsAPR: estimatedKatRewardsAPR,
     rewardToken:
       estimatedKatRewardsAPR !== null && estimatedKatRewardsAPR > 0

--- a/src/app/services/externalApis/yearnApi.ts
+++ b/src/app/services/externalApis/yearnApi.ts
@@ -28,7 +28,6 @@ type KongVaultCompositionItem = {
   totalLoss?: string
   lastReport?: string | number
   performanceFee?: string | number
-  latestReportApr?: number | null
   performance?: {
     estimated?: {
       components?: Record<string, number | string | null>
@@ -162,11 +161,6 @@ const calculateTokenPrice = (
   return normalizedAssets > 0 ? tvl / normalizedAssets : 0
 }
 
-const toPositiveFiniteNumberOrNull = (value: unknown): number | null => {
-  const parsed = toFiniteNumberOrNull(value)
-  return parsed && parsed > 0 ? parsed : null
-}
-
 const isKatanaYearnVault = (vault: KongVaultListItem): boolean =>
   vault.origin === 'yearn' && vault.inclusion?.isKatana === true
 
@@ -214,7 +208,9 @@ const mapKongCompositionToYearnStrategy = (
     address: strategy.address,
     name: strategy.name || 'Unknown',
     status: totalDebt === '0' ? 'unallocated' : strategy.status,
-    netAPR: toPositiveFiniteNumberOrNull(strategy.latestReportApr),
+    // latestReportApr is a historical point-in-time measurement and parent
+    // composition snapshots can retain it after the strategy snapshot changes.
+    netAPR: null,
     strategyRewardsAPR: estimatedKatRewardsAPR,
     rewardToken:
       estimatedKatRewardsAPR !== null && estimatedKatRewardsAPR > 0

--- a/src/app/types/yearn.ts
+++ b/src/app/types/yearn.ts
@@ -20,8 +20,8 @@ export interface MorphoUnderlyingAPR {
   morphoBaseAPR: number
   morphoBaseAPY: number
   morphoRewardsAPR: number
-  estimatedAPR: number
-  estimatedAPY: number
+  estimatedAPR: number | null
+  estimatedAPY: number | null
 }
 
 export interface VaultMorphoUnderlyingAPR {


### PR DESCRIPTION
## Summary

For vaults that had morpho compounder strategies attached, the forwardAPY fallback for constituent strategies that were not compounders was incorrectly setting the forwardAPY to either netAPY or the value from the last report. This was leading to stale APY values to be attached to the estimated APY values for these strategies, which were forwarded on to the vault APY calculations. The fix is as follows:

- stop using Kong `latestReportApr` as a current strategy or vault forward APR
- prefer a successful live Morpho replacement APR when one is available
- otherwise use the Kong on-chain oracle APR, including a valid `0`
- mark missing or failed estimates as unavailable instead of substituting historical performance
- only preserve the existing vault forward APR when a debt-bearing strategy has neither a live Morpho replacement nor a valid Kong oracle APR
- expose `strategy.netAPR` only when backed by one of those forward sources

## Root cause

Kong parent vault snapshots can retain stale `composition[].latestReportApr` values after the corresponding strategy snapshot changes. The APR service mapped that historical value to `strategy.netAPR` and used it to fill gaps when composing a forward vault APR. This allowed stale report performance to appear as a current estimate.

The service also ignored `composition[].performance.oracle.apr`, even though Kong obtains that value from `getStrategyApr(address, 0)` on the deployed Katana APR oracle. This caused valid zero oracle APRs, such as those returned for the vbUSDC Steer LP strategies, to be treated as missing coverage.

## Impact

Strategy and vault forward APRs now follow this priority:

1. successful live Morpho replacement
2. Kong on-chain oracle APR, including zero
3. unavailable (`null`)

This prevents historical report APRs from propagating while allowing strategies with a valid zero oracle APR to participate in vault forward APR composition. If a debt-bearing strategy has neither source, the service produces no replacement parent `netAPR` or `netAPY` webhook output, so Kong keeps its existing stored forward value instead of refreshing it from historical strategy data. Existing stored Kong rows are not explicitly deleted by this change and continue through the normal Kong expiry or replacement lifecycle.

## Validation

- `bun run test:run` — 68 tests passed
- `bun run lint` — passed
- `bun run build` — passed
- `git diff --check` — passed

## Reviewer Notes

To test the original issue, review the vbWBTC vault and verify that `apr.forwardAPR.netAPR` no longer shows ~35% and instead matches the oracle value in Kong (~0). Also confirm that the "Morpho vbWBTC/yvUSDC Lender Borrower" strategy (`0x0432337365d89c0D73f1D0Cb263791F8f1B98D43`) does not show the same ~35% APR in the API response.

To test the Kong oracle fallback, review the vbUSDC vault and confirm that `apr.forwardAPR.netAPR` is non-null while both debt-bearing Steer LP strategies expose `netAPR: 0`, matching their Kong/on-chain oracle values.