### PR TITLE
fix(deploy): no next.config env inlining, pin yearn-gha sync

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   deploy:
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@85539822185a390dc40d3130add72a1d449dbd31
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@5fc61270a5870d33a62e55bfedf054a9e833bb29
     with:
       vault: webops-prod-katana-apr-service
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   deploy:
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@711efc3dc97f65bbf6d6045d593732a935171e32
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@2ad17abdf9e8fb1024e5a369ce70cfa78c7af66a
     with:
       vault: webops-prod-katana-apr-service
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   deploy:
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@67e88b5ed430f4b8dbb6624a1148ea8fc4e72ed5
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@85539822185a390dc40d3130add72a1d449dbd31
     with:
       vault: webops-prod-katana-apr-service
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   deploy:
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@2ad17abdf9e8fb1024e5a369ce70cfa78c7af66a
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@67e88b5ed430f4b8dbb6624a1148ea8fc4e72ed5
     with:
       vault: webops-prod-katana-apr-service
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,31 +1,9 @@
 import type { NextConfig } from "next";
 
-// Runtime config sourced from 1Password via yearn-gha vercel-deploy and
-// injected at `vercel build` time (see .github/workflows/deploy.yml). Listed
-// vars are inlined into the build output so nothing has to live in Vercel's
-// env store. All are referenced server-side only, so they never reach the
-// client bundle.
-const INLINED_ENV = [
-  "RPC_URL_KATANA",
-  "KONG_WEBHOOK_SECRET",
-  "COINGECKO_API_KEY",
-  "KONG_BASE_URI",
-  "YDAEMON_BASE_URI",
-  "MERKL_BASE_URI",
-  "COINGECKO_BASE_URI",
-  "COINGECKO_KATANA_COIN_ID",
-  "KATANA_APR_SERVICE_API",
-  "MERKL_API_KEY",
-] as const;
-
-// Only inline vars that are actually set, so code-level `|| default` fallbacks
-// still apply when a var is absent (e.g. local dev).
-const env = Object.fromEntries(
-  INLINED_ENV.flatMap((k) => (process.env[k] ? [[k, process.env[k]!]] : [])),
-);
-
-const nextConfig: NextConfig = {
-  env,
-};
+// Secrets are synced from 1Password into the Vercel project env by
+// yearn-gha vercel-deploy (see .github/workflows/deploy.yml). Read them
+// via process.env on the server. Do not list secrets under `env` here —
+// next.config env force-inlines values and can leak into client assets.
+const nextConfig: NextConfig = {};
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Stop force-inlining deploy secrets through `next.config` `env` (murderteeth High: client-bundle leak risk). Secrets come from 1Password via yearn-gha, upserted into Vercel env for the deploy target; app code uses `process.env`.

## Changes

- Remove `INLINED_ENV` from `next.config.ts`
- Pin `yearn-gha` vercel-deploy to `2ad17ab` (1P→Vercel sync)

Depends on: https://github.com/yearn/yearn-gha/pull/3

## Testing

- not run