### PR TITLE
feat: add doppler integration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,4 +19,4 @@ jobs:
     uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@9701cd661a98fda358bb7b273b2baab97f12dea2
     with:
       project: katana-apr-service
-      identity-id: ${{ github.event_name == 'pull_request' && secrets.DOPPLER_PREVIEW_IDENTITY_ID || secrets.DOPPLER_PRODUCTION_IDENTITY_ID }}
+      identity-id: ${{ github.event_name == 'pull_request' && vars.DOPPLER_PREVIEW_IDENTITY_ID || vars.DOPPLER_PRODUCTION_IDENTITY_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,24 +16,7 @@ permissions:
 
 jobs:
   deploy:
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@711efc3dc97f65bbf6d6045d593732a935171e32
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@9701cd661a98fda358bb7b273b2baab97f12dea2
     with:
-      vault: webops-prod-katana-apr-service
-      environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
-      secrets: |
-        KONG_BASE_URI=katana-apr-service/KONG_BASE_URI
-        KONG_WEBHOOK_SECRET=katana-apr-service/KONG_WEBHOOK_SECRET
-        COINGECKO_API_KEY=katana-apr-service/COINGECKO_API_KEY
-        RPC_URL_KATANA=katana-apr-service/RPC_URL_KATANA
-        COINGECKO_BASE_URI=katana-apr-service/COINGECKO_BASE_URI
-        COINGECKO_KATANA_COIN_ID=katana-apr-service/COINGECKO_KATANA_COIN_ID
-        KATANA_APR_SERVICE_API=katana-apr-service/KATANA_APR_SERVICE_API
-        YDAEMON_BASE_URI=katana-apr-service/YDAEMON_BASE_URI
-        MERKL_BASE_URI=katana-apr-service/MERKL_BASE_URI
-        MERKL_API_KEY=katana-apr-service/MERKL_API_KEY
-        OTEL_EXPORTER_OTLP_ENDPOINT=katana-apr-service/OTEL_EXPORTER_OTLP_ENDPOINT
-        OTEL_EXPORTER_OTLP_HEADERS=katana-apr-service/OTEL_EXPORTER_OTLP_HEADERS
-        OTEL_SERVICE_NAME=katana-apr-service/OTEL_SERVICE_NAME
-        OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=katana-apr-service/OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
-    secrets:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      project: katana-apr-service
+      identity-id: ${{ github.event_name == 'pull_request' && secrets.DOPPLER_PREVIEW_IDENTITY_ID || secrets.DOPPLER_PRODUCTION_IDENTITY_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ permissions:
   contents: read
   deployments: write
   pull-requests: write
+  id-token: write
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary

Switches the Vercel deploy caller from 1Password to Doppler OIDC.

`.github/workflows/deploy.yml` is the only change. It pins `yearn/yearn-gha` `vercel-deploy.yml` to `9701cd661a98fda358bb7b273b2baab97f12dea2`, grants `id-token: write`, and passes `project: katana-apr-service` plus a Doppler identity:

- PRs: `vars.DOPPLER_PREVIEW_IDENTITY_ID`
- push to `main`: `vars.DOPPLER_PRODUCTION_IDENTITY_ID`

Removed the 1Password contract: `vault`, `environment`, the per-secret path list, and `secrets.OP_SERVICE_ACCOUNT_TOKEN`.

## Why

The reusable workflow no longer accepts 1Password inputs. It fetches only Vercel deploy credentials (`VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`) from Doppler `deploy-configs` over OIDC. App runtime secrets are not injected in Actions; they have to reach Vercel through Doppler syncs.

Preview vs production is derived from the event (PR vs push to `main`), so this caller no longer passes `environment`.

## Impact

- Repo variables `DOPPLER_PREVIEW_IDENTITY_ID` and `DOPPLER_PRODUCTION_IDENTITY_ID` must stay set. An empty identity fails the deploy.
- After merge, production deploys stop reading `OP_SERVICE_ACCOUNT_TOKEN`. That secret can be removed from the repo once this is the only deploy path.
- Adding or rotating an app secret is a Doppler/Vercel-sync change. This workflow no longer lists `KONG_*`, `COINGECKO_*`, `RPC_URL_KATANA`, `MERKL_*`, or `OTEL_*`.
- Fork PRs cannot deploy. The reusable workflow rejects them because GitHub does not issue an OIDC token.

## How to review

Read `.github/workflows/deploy.yml`. It should match `yearn/yearn-gha` `examples/katana-apr-service/deploy.yml` at the same pin, with the SHA filled in.

## Validation

- `deploy / Deploy to Vercel` on this PR: success
- Preview: https://katana-apr-service-haq1eynaf-yearn.vercel.app
- Production identity path is not exercised until a push to `main`
- No app, test, or lint changes
