### PR TITLE
Expose forward estimate debt coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ yarn-error.log*
 next-env.d.ts
 
 .codex
+/docs/investigations

--- a/docs/api-integration-guide.md
+++ b/docs/api-integration-guide.md
@@ -406,8 +406,8 @@ Notes:
   - `katanaNativeYield`
   - `steerPointsPerDollar` (legacy, always `0`)
 - Also emits strategy-addressed `katRewardsAPR` rows for strategies where `strategyRewardsAPR` is present, reusing the incoming estimated-APR label so Kong can hydrate them onto vault composition entries.
-- When live Morpho estimates contribute to a vault forward APR, also emits these vault-addressed diagnostics:
-  - `estimatedDebtCoverage`: share of total active strategy debt backed by live Morpho estimates; oracle-fallback debt is excluded
+- When Morpho underlying results are available and every allocated strategy has either a live estimate or oracle fallback, also emits these vault-addressed diagnostics:
+  - `estimatedDebtCoverage`: share of allocated strategy debt backed by live Morpho estimates; oracle-fallback debt is excluded, and vaults with no allocated debt report `1`
   - `morphoBaseAPY`: vault-asset-weighted Morpho base APY contribution
   - `morphoRewardsAPR`: vault-asset-weighted non-KAT Morpho rewards APR contribution
 - Diagnostic rows use the same finite-number guard as other estimated rows: explicit zero values are emitted, while non-finite values are omitted.

--- a/docs/api-integration-guide.md
+++ b/docs/api-integration-guide.md
@@ -406,6 +406,11 @@ Notes:
   - `katanaNativeYield`
   - `steerPointsPerDollar` (legacy, always `0`)
 - Also emits strategy-addressed `katRewardsAPR` rows for strategies where `strategyRewardsAPR` is present, reusing the incoming estimated-APR label so Kong can hydrate them onto vault composition entries.
+- When live Morpho estimates contribute to a vault forward APR, also emits these vault-addressed diagnostics:
+  - `estimatedDebtCoverage`: share of total active strategy debt backed by live Morpho estimates; oracle-fallback debt is excluded
+  - `morphoBaseAPY`: vault-asset-weighted Morpho base APY contribution
+  - `morphoRewardsAPR`: vault-asset-weighted non-KAT Morpho rewards APR contribution
+- Diagnostic rows use the same finite-number guard as other estimated rows: explicit zero values are emitted, while non-finite values are omitted.
 
 ### `GET /api/health`
 

--- a/src/app/api/webhook/route.test.ts
+++ b/src/app/api/webhook/route.test.ts
@@ -120,6 +120,7 @@ describe('/api/webhook route', () => {
             },
             morphoUnderlying: {
               baseAPR: 0.02,
+              baseAPY: 0.0204,
               rewardsAPR: 0.01,
               estimatedAPR: 0.03,
               estimatedAPY: 0.0305,
@@ -151,9 +152,6 @@ describe('/api/webhook route', () => {
     const body = await response.json()
 
     expect(response.status).toBe(200)
-    expect(body).not.toContainEqual(
-      expect.objectContaining({ component: 'morphoRewardsAPR' }),
-    )
     expect(body).not.toContainEqual(
       expect.objectContaining({ component: 'estimatedAPR' }),
     )
@@ -254,6 +252,33 @@ describe('/api/webhook route', () => {
         label: 'katana',
         component: 'katRewardsAPR',
         value: 0,
+        blockNumber: '123',
+        blockTime: '456',
+      },
+      {
+        chainId: 747474,
+        address: REQUEST_VAULT_ADDRESS,
+        label: 'katana',
+        component: 'estimatedDebtCoverage',
+        value: 0.5,
+        blockNumber: '123',
+        blockTime: '456',
+      },
+      {
+        chainId: 747474,
+        address: REQUEST_VAULT_ADDRESS,
+        label: 'katana',
+        component: 'morphoBaseAPY',
+        value: 0.0204,
+        blockNumber: '123',
+        blockTime: '456',
+      },
+      {
+        chainId: 747474,
+        address: REQUEST_VAULT_ADDRESS,
+        label: 'katana',
+        component: 'morphoRewardsAPR',
+        value: 0.01,
         blockNumber: '123',
         blockTime: '456',
       },
@@ -429,6 +454,73 @@ describe('/api/webhook route', () => {
       blockNumber: '123',
       blockTime: '456',
     })
+  })
+
+  it('emits zero Morpho diagnostics and suppresses non-finite values', async () => {
+    mocks.mockGenerateVaultAPRData.mockResolvedValue({
+      [VAULT_ADDRESS.toLowerCase()]: {
+        address: VAULT_ADDRESS,
+        symbol: 'yvKAT',
+        name: 'KAT Vault',
+        chainID: 747474,
+        strategies: [],
+        apr: {
+          forwardAPR: {
+            type: '',
+            netAPR: 0,
+            composite: {
+              boost: null,
+              poolAPY: null,
+              boostedAPR: null,
+              baseAPR: null,
+              cvxAPR: null,
+              rewardsAPR: null,
+            },
+            morphoUnderlying: {
+              baseAPR: 0,
+              baseAPY: 0,
+              rewardsAPR: Number.POSITIVE_INFINITY,
+              estimatedAPR: 0,
+              estimatedAPY: 0,
+              coveredDebtRatio: 0,
+            },
+          },
+          extra: {},
+        },
+      },
+    })
+
+    const response = await POST(
+      buildSignedRequest({
+        vaults: [REQUEST_VAULT_ADDRESS],
+        chainId: 747474,
+        blockNumber: '123',
+        blockTime: '456',
+        subscription: {
+          labels: ['katana-estimated-apr'],
+        },
+      }),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toContainEqual(
+      expect.objectContaining({
+        address: REQUEST_VAULT_ADDRESS,
+        component: 'estimatedDebtCoverage',
+        value: 0,
+      }),
+    )
+    expect(body).toContainEqual(
+      expect.objectContaining({
+        address: REQUEST_VAULT_ADDRESS,
+        component: 'morphoBaseAPY',
+        value: 0,
+      }),
+    )
+    expect(body).not.toContainEqual(
+      expect.objectContaining({ component: 'morphoRewardsAPR' }),
+    )
   })
 
   it('does not emit forward APR or APY rows for null, missing, or non-finite values', async () => {

--- a/src/app/api/webhook/route.ts
+++ b/src/app/api/webhook/route.ts
@@ -3,7 +3,11 @@ import { createHmac, timingSafeEqual } from 'node:crypto'
 import { captureError, flushObservability } from '../../../observability'
 
 import { DataCacheService } from '../../services/dataCache'
-import type { YearnStrategy, YearnVaultExtra } from '../../types/yearn'
+import type {
+  VaultMorphoUnderlyingAPR,
+  YearnStrategy,
+  YearnVaultExtra,
+} from '../../types/yearn'
 
 export const dynamic = 'force-dynamic'
 
@@ -174,6 +178,29 @@ function buildForwardAPROutputs(
   ]
 }
 
+function buildMorphoUnderlyingOutputs(
+  address: string,
+  morphoUnderlying: VaultMorphoUnderlyingAPR | undefined,
+  base: Omit<KongOutput, 'address' | 'component' | 'value'>,
+): KongOutput[] {
+  if (!morphoUnderlying) {
+    return []
+  }
+
+  const components: Array<[string, number]> = [
+    ['estimatedDebtCoverage', morphoUnderlying.coveredDebtRatio],
+    ['morphoBaseAPY', morphoUnderlying.baseAPY],
+    ['morphoRewardsAPR', morphoUnderlying.rewardsAPR],
+  ]
+
+  return components.flatMap(([component, value]) => {
+    const finiteValue = toFiniteNumber(value)
+    return finiteValue == null
+      ? []
+      : [{ ...base, address, component, value: finiteValue }]
+  })
+}
+
 export async function POST(req: NextRequest): Promise<Response> {
   const secret = process.env.KONG_WEBHOOK_SECRET
   if (!secret) {
@@ -221,6 +248,13 @@ export async function POST(req: NextRequest): Promise<Response> {
         ),
       )
       outputs.push(...buildStrategyOutputs(vault.strategies || [], base))
+      outputs.push(
+        ...buildMorphoUnderlyingOutputs(
+          address,
+          vault.apr?.forwardAPR?.morphoUnderlying,
+          base,
+        ),
+      )
     }
 
     return jsonResponseWithBigInt(outputs)

--- a/src/app/services/dataCache.test.ts
+++ b/src/app/services/dataCache.test.ts
@@ -511,6 +511,72 @@ describe('DataCacheService.generateVaultAPRData', () => {
     ).toBe(0)
   })
 
+  it('uses the forward APR allocation weights for estimated debt coverage', async () => {
+    const liveMorphoStrategyAddress =
+      '0x00000000000000000000000000000000000000fb'
+    const fallbackStrategyAddress =
+      '0x00000000000000000000000000000000000000fc'
+    const vault = makeVault({
+      tvl: {
+        totalAssets: '100',
+        tvl: 100,
+        price: 1,
+      },
+      strategies: [
+        {
+          address: liveMorphoStrategyAddress,
+          name: 'Morpho Yearn USDC Compounder',
+          status: 'active',
+          netAPR: 0.01,
+          details: {
+            totalDebt: '60',
+            totalGain: '0',
+            totalLoss: '0',
+            lastReport: 0,
+            debtRatio: 6000,
+          },
+        },
+        {
+          address: fallbackStrategyAddress,
+          name: 'Steer USDC Strategy',
+          status: 'active',
+          netAPR: 0,
+          details: {
+            totalDebt: '0',
+            totalGain: '0',
+            totalLoss: '0',
+            lastReport: 0,
+            debtRatio: 4000,
+          },
+        },
+      ],
+    })
+    mocks.mockGetVaults.mockResolvedValue([vault])
+    mocks.mockCalculateMorphoUnderlyingVaultAPRs.mockResolvedValue({
+      [vault.address]: [
+        {
+          strategyAddress: liveMorphoStrategyAddress,
+          morphoVaultAddress:
+            '0x00000000000000000000000000000000000000ab',
+          morphoBaseAPR: 0.08,
+          morphoBaseAPY: 0.0832,
+          morphoRewardsAPR: 0.02,
+          replacementAPR: 0.10,
+          estimatedAPY: (1 + 0.10 / 52) ** 52 - 1,
+          usedMorphoApi: true,
+        },
+      ],
+    })
+
+    const service = new DataCacheService()
+    const data = await service.generateVaultAPRData()
+
+    expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(0.06)
+    expect(
+      data[vault.address].apr?.forwardAPR?.morphoUnderlying?.coveredDebtRatio,
+    ).toBeCloseTo(0.6)
+  })
+
   it('reports full estimated debt coverage for a zero-yield live Morpho estimate', async () => {
     const morphoStrategyAddress =
       '0x00000000000000000000000000000000000000f9'

--- a/src/app/services/dataCache.test.ts
+++ b/src/app/services/dataCache.test.ts
@@ -420,10 +420,11 @@ describe('DataCacheService.generateVaultAPRData', () => {
     )
     expect(data[vault.address].apr?.forwardAPR?.morphoUnderlying).toEqual({
       baseAPR: 0.08 * 0.5,
+      baseAPY: 0.0832 * 0.5,
       rewardsAPR: 0.02 * 0.5,
       estimatedAPR: 0.10 * 0.5,
       estimatedAPY: (1 + (0.10 * 0.5) / 52) ** 52 - 1,
-      coveredDebtRatio: 0.5,
+      coveredDebtRatio: 2 / 3,
     })
     expect(data[vault.address].strategies[0].netAPR).toBe(0.10)
     expect(data[vault.address].strategies[1].netAPR).toBe(0)
@@ -505,6 +506,112 @@ describe('DataCacheService.generateVaultAPRData', () => {
       estimatedAPR: null,
       estimatedAPY: null,
     })
+    expect(
+      data[vault.address].apr?.forwardAPR?.morphoUnderlying?.coveredDebtRatio,
+    ).toBe(0)
+  })
+
+  it('reports full estimated debt coverage for a zero-yield live Morpho estimate', async () => {
+    const morphoStrategyAddress =
+      '0x00000000000000000000000000000000000000f9'
+    const vault = makeVault({
+      tvl: {
+        totalAssets: '100',
+        tvl: 100,
+        price: 1,
+      },
+      strategies: [
+        {
+          address: morphoStrategyAddress,
+          name: 'Morpho Yearn USDC Compounder',
+          status: 'active',
+          details: {
+            totalDebt: '60',
+            totalGain: '0',
+            totalLoss: '0',
+            lastReport: 0,
+            debtRatio: 6000,
+          },
+        },
+      ],
+    })
+    mocks.mockGetVaults.mockResolvedValue([vault])
+    mocks.mockCalculateMorphoUnderlyingVaultAPRs.mockResolvedValue({
+      [vault.address]: [
+        {
+          strategyAddress: morphoStrategyAddress,
+          morphoVaultAddress:
+            '0x00000000000000000000000000000000000000a9',
+          morphoBaseAPR: 0,
+          morphoBaseAPY: 0,
+          morphoRewardsAPR: 0,
+          replacementAPR: 0,
+          estimatedAPY: 0,
+          usedMorphoApi: true,
+        },
+      ],
+    })
+
+    const service = new DataCacheService()
+    const data = await service.generateVaultAPRData()
+
+    expect(data[vault.address].apr?.forwardAPR?.netAPR).toBe(0)
+    expect(data[vault.address].apr?.forwardAPR?.morphoUnderlying).toEqual({
+      baseAPR: 0,
+      baseAPY: 0,
+      rewardsAPR: 0,
+      estimatedAPR: 0,
+      estimatedAPY: 0,
+      coveredDebtRatio: 1,
+    })
+  })
+
+  it('reports full coverage when the vault has no active strategy debt', async () => {
+    const idleStrategyAddress =
+      '0x00000000000000000000000000000000000000fa'
+    const vault = makeVault({
+      tvl: {
+        totalAssets: '100',
+        tvl: 100,
+        price: 1,
+      },
+      strategies: [
+        {
+          address: idleStrategyAddress,
+          name: 'Morpho Idle USDC Compounder',
+          status: 'unallocated',
+          details: {
+            totalDebt: '0',
+            totalGain: '0',
+            totalLoss: '0',
+            lastReport: 0,
+          },
+        },
+      ],
+    })
+    mocks.mockGetVaults.mockResolvedValue([vault])
+    mocks.mockCalculateMorphoUnderlyingVaultAPRs.mockResolvedValue({
+      [vault.address]: [
+        {
+          strategyAddress: idleStrategyAddress,
+          morphoVaultAddress:
+            '0x00000000000000000000000000000000000000aa',
+          morphoBaseAPR: 0.02,
+          morphoBaseAPY: 0.0202,
+          morphoRewardsAPR: 0.01,
+          replacementAPR: 0.03,
+          estimatedAPY: (1 + 0.03 / 52) ** 52 - 1,
+          usedMorphoApi: true,
+        },
+      ],
+    })
+
+    const service = new DataCacheService()
+    const data = await service.generateVaultAPRData()
+
+    expect(
+      data[vault.address].apr?.forwardAPR?.morphoUnderlying?.coveredDebtRatio,
+    ).toBe(1)
   })
 
   it('keeps forward APR unchanged when there are no Morpho replacement results', async () => {

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -366,6 +366,26 @@ export class DataCacheService {
       MorphoUnderlyingAprResult & { replacementAPR: number }
     >,
   ): NonNullable<YearnVaultAPY['forwardAPR']>['morphoUnderlying'] {
+    const liveMorphoStrategyAddresses = new Set(
+      morphoUnderlyingResults.map((result) =>
+        result.strategyAddress.toLowerCase(),
+      ),
+    )
+    const { coveredDebt, totalActiveDebt } = vault.strategies.reduce(
+      (accumulator, strategy) => {
+        const strategyDebt = this.getStrategyDebt(strategy)
+        if (strategyDebt <= BigInt(0)) {
+          return accumulator
+        }
+
+        accumulator.totalActiveDebt += strategyDebt
+        if (liveMorphoStrategyAddresses.has(strategy.address.toLowerCase())) {
+          accumulator.coveredDebt += strategyDebt
+        }
+        return accumulator
+      },
+      { coveredDebt: BigInt(0), totalActiveDebt: BigInt(0) },
+    )
     const weighted = morphoUnderlyingResults.reduce(
       (accumulator, result) => {
         const strategy = vault.strategies.find(
@@ -383,22 +403,26 @@ export class DataCacheService {
         }
 
         accumulator.baseAPR += result.morphoBaseAPR * debtShare
+        accumulator.baseAPY += result.morphoBaseAPY * debtShare
         accumulator.rewardsAPR += result.morphoRewardsAPR * debtShare
         accumulator.estimatedAPR += result.replacementAPR * debtShare
-        accumulator.coveredDebtRatio += debtShare
         return accumulator
       },
       {
         baseAPR: 0,
+        baseAPY: 0,
         rewardsAPR: 0,
         estimatedAPR: 0,
-        coveredDebtRatio: 0,
       },
     )
 
     return {
       ...weighted,
       estimatedAPY: this.convertAprToWeeklyApy(weighted.estimatedAPR),
+      coveredDebtRatio:
+        totalActiveDebt > BigInt(0)
+          ? Number(coveredDebt) / Number(totalActiveDebt)
+          : 1,
     }
   }
 
@@ -445,8 +469,8 @@ export class DataCacheService {
       return debtRatio / 10_000
     }
 
+    const strategyDebt = this.getStrategyDebt(strategy)
     try {
-      const strategyDebt = BigInt(String(strategy.details?.totalDebt ?? '0'))
       const vaultTotalAssets = BigInt(String(vault.tvl?.totalAssets ?? '0'))
       if (strategyDebt <= BigInt(0) || vaultTotalAssets <= BigInt(0)) {
         return 0
@@ -455,6 +479,15 @@ export class DataCacheService {
       return Number(strategyDebt) / Number(vaultTotalAssets)
     } catch {
       return 0
+    }
+  }
+
+  private getStrategyDebt(strategy: YearnStrategy): bigint {
+    try {
+      const strategyDebt = BigInt(String(strategy.details?.totalDebt ?? '0'))
+      return strategyDebt > BigInt(0) ? strategyDebt : BigInt(0)
+    } catch {
+      return BigInt(0)
     }
   }
 

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -36,6 +36,11 @@ interface StrategyRewardSummary {
   underlyingContract?: string
 }
 
+interface StrategyAllocation {
+  strategy: YearnStrategy
+  debtShare: number
+}
+
 const KATANA_ACCOUNTANT_DEFAULT_MAX_FEE = 0.5
 
 export class DataCacheService {
@@ -310,6 +315,9 @@ export class DataCacheService {
         result.replacementAPR,
       ]),
     )
+    const liveMorphoStrategyAddresses = new Set(
+      morphoReplacementByStrategy.keys(),
+    )
     const allocatedStrategies = (vault.strategies || [])
       .map((strategy) => ({
         strategy,
@@ -354,58 +362,56 @@ export class DataCacheService {
         rewardsAPR: null,
       },
       morphoUnderlying: this.buildVaultMorphoUnderlyingAPR(
-        vault,
+        allocatedStrategies,
         liveMorphoResults,
+        liveMorphoStrategyAddresses,
       ),
     }
   }
 
   private buildVaultMorphoUnderlyingAPR(
-    vault: YearnVault,
+    allocatedStrategies: StrategyAllocation[],
     morphoUnderlyingResults: Array<
       MorphoUnderlyingAprResult & { replacementAPR: number }
     >,
+    liveMorphoStrategyAddresses: ReadonlySet<string>,
   ): NonNullable<YearnVaultAPY['forwardAPR']>['morphoUnderlying'] {
-    const liveMorphoStrategyAddresses = new Set(
-      morphoUnderlyingResults.map((result) =>
-        result.strategyAddress.toLowerCase(),
-      ),
+    const allocationsByStrategy = new Map(
+      allocatedStrategies.map((allocation) => [
+        allocation.strategy.address.toLowerCase(),
+        allocation,
+      ]),
     )
-    const { coveredDebt, totalActiveDebt } = vault.strategies.reduce(
-      (accumulator, strategy) => {
-        const strategyDebt = this.getStrategyDebt(strategy)
-        if (strategyDebt <= BigInt(0)) {
+    const { coveredDebtShare, totalAllocatedDebtShare } =
+      allocatedStrategies.reduce(
+        (accumulator, allocation) => {
+          accumulator.totalAllocatedDebtShare += allocation.debtShare
+          if (
+            liveMorphoStrategyAddresses.has(
+              allocation.strategy.address.toLowerCase(),
+            )
+          ) {
+            accumulator.coveredDebtShare += allocation.debtShare
+          }
           return accumulator
-        }
-
-        accumulator.totalActiveDebt += strategyDebt
-        if (liveMorphoStrategyAddresses.has(strategy.address.toLowerCase())) {
-          accumulator.coveredDebt += strategyDebt
-        }
-        return accumulator
-      },
-      { coveredDebt: BigInt(0), totalActiveDebt: BigInt(0) },
-    )
+        },
+        { coveredDebtShare: 0, totalAllocatedDebtShare: 0 },
+      )
     const weighted = morphoUnderlyingResults.reduce(
       (accumulator, result) => {
-        const strategy = vault.strategies.find(
-          (candidate) =>
-            candidate.address.toLowerCase() ===
-            result.strategyAddress.toLowerCase(),
+        const allocation = allocationsByStrategy.get(
+          result.strategyAddress.toLowerCase(),
         )
-        if (!strategy) {
+        if (!allocation) {
           return accumulator
         }
 
-        const debtShare = this.getStrategyDebtShare(strategy, vault)
-        if (debtShare <= 0) {
-          return accumulator
-        }
-
-        accumulator.baseAPR += result.morphoBaseAPR * debtShare
-        accumulator.baseAPY += result.morphoBaseAPY * debtShare
-        accumulator.rewardsAPR += result.morphoRewardsAPR * debtShare
-        accumulator.estimatedAPR += result.replacementAPR * debtShare
+        accumulator.baseAPR += result.morphoBaseAPR * allocation.debtShare
+        accumulator.baseAPY += result.morphoBaseAPY * allocation.debtShare
+        accumulator.rewardsAPR +=
+          result.morphoRewardsAPR * allocation.debtShare
+        accumulator.estimatedAPR +=
+          result.replacementAPR * allocation.debtShare
         return accumulator
       },
       {
@@ -420,8 +426,8 @@ export class DataCacheService {
       ...weighted,
       estimatedAPY: this.convertAprToWeeklyApy(weighted.estimatedAPR),
       coveredDebtRatio:
-        totalActiveDebt > BigInt(0)
-          ? Number(coveredDebt) / Number(totalActiveDebt)
+        totalAllocatedDebtShare > 0
+          ? coveredDebtShare / totalAllocatedDebtShare
           : 1,
     }
   }

--- a/src/app/types/yearn.ts
+++ b/src/app/types/yearn.ts
@@ -26,6 +26,7 @@ export interface MorphoUnderlyingAPR {
 
 export interface VaultMorphoUnderlyingAPR {
   baseAPR: number
+  baseAPY: number
   rewardsAPR: number
   estimatedAPR: number
   estimatedAPY: number


### PR DESCRIPTION
### Summary
Katana vault forward APR can mix live Morpho estimates with Kong oracle fallback without showing how much allocated strategy debt uses the live estimate. This change publishes debt coverage, Morpho base APY, and Morpho rewards APR as vault-addressed webhook components.

It also documents the new fields and ignores local investigation documents.

Related to #49

### How to review
Review `buildVaultMorphoUnderlyingAPR` first. Confirm that coverage and weighted yield components reuse the forward APR allocation weights: live Morpho allocations contribute to coverage, while oracle-fallback allocations remain in the denominator.

Then review the webhook helper and tests. Existing forward, strategy, and KAT rows should remain unchanged. UI pages can be skipped because this PR does not change the interface.

### Test plan
- [x] Manual: Queried `/api/vaults` from a production build and independently recomputed the emitted coverage ratios for live vaults.
- [x] Automated: `bun run test:run` (73 tests passed)
- [x] Automated: `bun run lint`
- [x] Automated: `bun run build`
- [x] Automated: `git diff --check origin/main...HEAD`

### Risk / impact
Risk is low and limited to estimated-APR diagnostics. The public `/api/vaults` response changes the existing `forwardAPR.morphoUnderlying.coveredDebtRatio` from a vault-asset-weighted live share to the live share of all allocated strategy debt, and adds `baseAPY` to that diagnostic object. The webhook adds three component rows.

This does not change fallback selection, forward APR values, strategy eligibility, KAT reward handling, authentication, or database state. The new rows are safe before the matching Kong GraphQL fields ship because Kong stores them in its generic components record. Revert the PR commits to roll back the publisher changes.
