### PR TITLE
Add Merkl fallback for Morpho estimates

### DIFF
--- a/docs/api-integration-guide.md
+++ b/docs/api-integration-guide.md
@@ -341,6 +341,36 @@ Snippet:
 
 ### 5) Service output shape (post-TGE computed extras)
 
+#### Morpho forward-estimate ladder
+
+Resolved Morpho compounder strategies select the first available estimate in
+this order:
+
+1. Morpho API base APY plus non-KAT rewards APR.
+2. Merkl rewards matched to the resolved Morpho vault address.
+3. Merkl rewards matched to the strategy address.
+4. Kong's on-chain strategy APR oracle, including an explicit zero.
+
+Merkl matching considers live `MORPHOVAULT` opportunities first and then live
+`ERC20LOGPROCESSOR` opportunities at the same exact address. Only campaigns
+that remain after blacklist filtering, pay a non-KAT token, and have a matching
+APR breakdown contribute. Merkl breakdowns are percentages and are divided by
+`100` before use. The Kong oracle APR acts as the base proxy for a Merkl
+fallback; when it is unavailable, the Merkl rewards APR stands alone.
+
+`strategies[].morphoUnderlyingAPR.morphoEstimateSource` discloses the selected
+source numerically:
+
+- `0`: Morpho API
+- `1`: Merkl at the underlying Morpho vault address
+- `2`: Merkl at the strategy address
+- `3`: Kong oracle
+
+Sources `0` through `2` count toward `estimatedDebtCoverage`. Source `3` keeps
+the vault forward estimate complete but does not count as real-estimate
+coverage. A strategy with no finite value from any rung can still cause the
+vault calculation to retain the upstream forward APR.
+
 From `DataCacheService.generateVaultAPRData()`:
 
 Notes:
@@ -406,8 +436,9 @@ Notes:
   - `katanaNativeYield`
   - `steerPointsPerDollar` (legacy, always `0`)
 - Also emits strategy-addressed `katRewardsAPR` rows for strategies where `strategyRewardsAPR` is present, reusing the incoming estimated-APR label so Kong can hydrate them onto vault composition entries.
-- When live Morpho estimates contribute to a vault forward APR, also emits these vault-addressed diagnostics:
-  - `estimatedDebtCoverage`: share of total active strategy debt backed by live Morpho estimates; oracle-fallback debt is excluded
+- Emits strategy-addressed `morphoEstimateSource` alongside each finite Morpho forward estimate.
+- When Morpho API or Merkl estimates contribute to a vault forward APR, also emits these vault-addressed diagnostics:
+  - `estimatedDebtCoverage`: share of total active strategy debt backed by Morpho API or Merkl estimates; oracle-fallback debt is excluded
   - `morphoBaseAPY`: vault-asset-weighted Morpho base APY contribution
   - `morphoRewardsAPR`: vault-asset-weighted non-KAT Morpho rewards APR contribution
 - Diagnostic rows use the same finite-number guard as other estimated rows: explicit zero values are emitted, while non-finite values are omitted.

--- a/src/app/api/webhook/route.test.ts
+++ b/src/app/api/webhook/route.test.ts
@@ -1,6 +1,7 @@
 import { createHmac } from 'node:crypto'
 import { NextRequest } from 'next/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MORPHO_ESTIMATE_SOURCE } from '../../types/yearn'
 
 const mocks = vi.hoisted(() => ({
   mockGenerateVaultAPRData: vi.fn(),
@@ -84,6 +85,7 @@ describe('/api/webhook route', () => {
               morphoVaultAddress:
                 '0x00000000000000000000000000000000000000ee',
               usedMorphoApi: true,
+              morphoEstimateSource: MORPHO_ESTIMATE_SOURCE.MORPHO_API,
               morphoBaseAPR: 0.04,
               morphoBaseAPY: 0.0408,
               morphoRewardsAPR: 0.02,
@@ -241,6 +243,15 @@ describe('/api/webhook route', () => {
         chainId: 747474,
         address: STRATEGY_ADDRESS,
         label: 'katana',
+        component: 'morphoEstimateSource',
+        value: MORPHO_ESTIMATE_SOURCE.MORPHO_API,
+        blockNumber: '123',
+        blockTime: '456',
+      },
+      {
+        chainId: 747474,
+        address: STRATEGY_ADDRESS,
+        label: 'katana',
         component: 'katRewardsAPR',
         value: 0.123,
         blockNumber: '123',
@@ -306,6 +317,7 @@ describe('/api/webhook route', () => {
               morphoVaultAddress:
                 '0x00000000000000000000000000000000000000e1',
               usedMorphoApi: true,
+              morphoEstimateSource: MORPHO_ESTIMATE_SOURCE.MORPHO_API,
               morphoBaseAPR: 0,
               morphoBaseAPY: 0,
               morphoRewardsAPR: 0,
@@ -321,6 +333,7 @@ describe('/api/webhook route', () => {
               morphoVaultAddress:
                 '0x00000000000000000000000000000000000000e2',
               usedMorphoApi: true,
+              morphoEstimateSource: MORPHO_ESTIMATE_SOURCE.MORPHO_API,
               morphoBaseAPR: 0,
               morphoBaseAPY: 0,
               morphoRewardsAPR: 0,
@@ -367,6 +380,15 @@ describe('/api/webhook route', () => {
       blockNumber: '123',
       blockTime: '456',
     })
+    expect(body).toContainEqual({
+      chainId: 747474,
+      address: zeroEstimateAddress,
+      label: 'katana-estimated-apr',
+      component: 'morphoEstimateSource',
+      value: MORPHO_ESTIMATE_SOURCE.MORPHO_API,
+      blockNumber: '123',
+      blockTime: '456',
+    })
     expect(body).not.toContainEqual(
       expect.objectContaining({
         address: zeroEstimateAddress,
@@ -383,6 +405,12 @@ describe('/api/webhook route', () => {
       expect.objectContaining({
         address: invalidEstimateAddress,
         component: 'netAPY',
+      }),
+    )
+    expect(body).not.toContainEqual(
+      expect.objectContaining({
+        address: invalidEstimateAddress,
+        component: 'morphoEstimateSource',
       }),
     )
     expect(body).toContainEqual({

--- a/src/app/api/webhook/route.ts
+++ b/src/app/api/webhook/route.ts
@@ -115,6 +115,9 @@ function buildStrategyOutputs(
     const estimatedAPY = toFiniteNumber(
       strategy.morphoUnderlyingAPR?.estimatedAPY,
     )
+    const morphoEstimateSource = toFiniteNumber(
+      strategy.morphoUnderlyingAPR?.morphoEstimateSource,
+    )
     const katRewardsAPR = toFiniteNumber(strategy.strategyRewardsAPR)
 
     if (estimatedAPR != null) {
@@ -132,6 +135,15 @@ function buildStrategyOutputs(
         address,
         component: 'netAPY',
         value: estimatedAPY,
+      })
+    }
+
+    if (estimatedAPR != null && morphoEstimateSource != null) {
+      outputs.push({
+        ...base,
+        address,
+        component: 'morphoEstimateSource',
+        value: morphoEstimateSource,
       })
     }
 

--- a/src/app/services/aprCalcs/morphoAprCalculator.ts
+++ b/src/app/services/aprCalcs/morphoAprCalculator.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import type { YearnVault } from '../../types'
+import type { MerklOpportunity, YearnVault } from '../../types'
 import { MerklApiService } from '../externalApis/merklApi'
 import { YearnApiService } from '../externalApis/yearnApi'
 import { ContractReaderService } from '../contractReader'
@@ -19,9 +19,12 @@ export class MorphoAprCalculator implements APRCalculator {
   }
 
   async calculateVaultAPRs(
-    vaults: YearnVault[]
+    vaults: YearnVault[],
+    suppliedMorphoOpportunities?: MerklOpportunity[],
   ): Promise<Record<string, RewardCalculatorResult[]>> {
-    const morphoOpportunities = await this.merklApi.getMorphoOpportunities()
+    const morphoOpportunities =
+      suppliedMorphoOpportunities ??
+      (await this.merklApi.getMorphoOpportunities())
 
     const vaultStrategyPairs = _.chain(vaults)
       .map((vault) => ({

--- a/src/app/services/aprCalcs/morphoUnderlyingAprCalculator.test.ts
+++ b/src/app/services/aprCalcs/morphoUnderlyingAprCalculator.test.ts
@@ -1,10 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { YearnVault } from '../../types'
+import {
+  MORPHO_ESTIMATE_SOURCE,
+  type MerklOpportunity,
+  type YearnVault,
+} from '../../types'
 
 const mocks = vi.hoisted(() => ({
   getMorphoCompounderStrategies: vi.fn(),
   getMorphoVaultsFromStrategies: vi.fn(),
   getVaultAprEstimates: vi.fn(),
+  getMorphoOpportunities: vi.fn(),
 }))
 
 vi.mock('../externalApis/yearnApi', () => ({
@@ -25,6 +30,12 @@ vi.mock('../externalApis/morphoApi', () => ({
   })),
 }))
 
+vi.mock('../externalApis/merklApi', () => ({
+  MerklApiService: vi.fn().mockImplementation(() => ({
+    getMorphoOpportunities: mocks.getMorphoOpportunities,
+  })),
+}))
+
 import { MorphoUnderlyingAprCalculator } from './morphoUnderlyingAprCalculator'
 
 const VAULT_ADDRESS = '0x00000000000000000000000000000000000000aa'
@@ -32,6 +43,48 @@ const COMPOUNDER_ADDRESS = '0x00000000000000000000000000000000000000bb'
 const LENDER_BORROWER_ADDRESS = '0x00000000000000000000000000000000000000cc'
 const STEER_ADDRESS = '0x00000000000000000000000000000000000000dd'
 const MORPHO_VAULT_ADDRESS = '0x00000000000000000000000000000000000000ee'
+const MORPHO_REWARD_TOKEN = '0x00000000000000000000000000000000000000f1'
+const KAT_REWARD_TOKEN = '0x7F1f4b4b29f5058fA32CC7a97141b8D7e5ABDC2d'
+const BLACKLISTED_CAMPAIGN_ID =
+  '0xc5a22d022154d5c64ff14b2f4071f134eb83cf159f9f846ad0ba0908a755e86d'
+
+const makeOpportunity = ({
+  address,
+  aprPercent,
+  campaignId,
+  rewardTokenAddress = MORPHO_REWARD_TOKEN,
+  type = 'ERC20LOGPROCESSOR',
+}: {
+  address: string
+  aprPercent: number
+  campaignId: string
+  rewardTokenAddress?: string
+  type?: string
+}): MerklOpportunity => ({
+  chainId: 747474,
+  name: 'Morpho reward opportunity',
+  tvl: 1_000_000,
+  identifier: address,
+  status: 'LIVE',
+  type,
+  campaigns: [
+    {
+      campaignId,
+      amount: '1',
+      rewardToken: {
+        address: rewardTokenAddress,
+        symbol: rewardTokenAddress === KAT_REWARD_TOKEN ? 'KAT' : 'MORPHO',
+        decimals: 18,
+        price: 1,
+      },
+      startTimestamp: 0,
+      endTimestamp: 0,
+    },
+  ],
+  aprRecord: {
+    breakdowns: [{ identifier: campaignId, value: aprPercent }],
+  },
+})
 
 const makeVault = (): YearnVault => ({
   address: VAULT_ADDRESS,
@@ -91,6 +144,8 @@ describe('MorphoUnderlyingAprCalculator', () => {
     mocks.getMorphoCompounderStrategies.mockReset()
     mocks.getMorphoVaultsFromStrategies.mockReset()
     mocks.getVaultAprEstimates.mockReset()
+    mocks.getMorphoOpportunities.mockReset()
+    mocks.getMorphoOpportunities.mockResolvedValue([])
   })
 
   it('uses dynamic vault mapping for selected compounders', async () => {
@@ -132,11 +187,12 @@ describe('MorphoUnderlyingAprCalculator', () => {
             52 -
           1,
         usedMorphoApi: true,
+        morphoEstimateSource: MORPHO_ESTIMATE_SOURCE.MORPHO_API,
       },
     ])
   })
 
-  it('marks the forward estimate unavailable when the Morpho estimate is missing', async () => {
+  it('falls through to the Kong oracle when Morpho and Merkl estimates are missing', async () => {
     const vault = makeVault()
     mocks.getMorphoCompounderStrategies.mockReturnValue([
       COMPOUNDER_ADDRESS,
@@ -153,13 +209,207 @@ describe('MorphoUnderlyingAprCalculator', () => {
       {
         strategyAddress: COMPOUNDER_ADDRESS,
         morphoVaultAddress: MORPHO_VAULT_ADDRESS,
-        morphoBaseAPR: 0,
-        morphoBaseAPY: 0,
+        morphoBaseAPR: 0.01,
+        morphoBaseAPY: (1 + 0.01 / 52) ** 52 - 1,
         morphoRewardsAPR: 0,
-        replacementAPR: null,
-        estimatedAPY: null,
+        replacementAPR: 0.01,
+        estimatedAPY: (1 + 0.01 / 52) ** 52 - 1,
         usedMorphoApi: false,
+        morphoEstimateSource: MORPHO_ESTIMATE_SOURCE.KONG_ORACLE,
       },
     ])
+  })
+
+  it('uses non-KAT Merkl rewards at the resolved underlying address during a Morpho outage', async () => {
+    const vault = makeVault()
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    mocks.getMorphoCompounderStrategies.mockReturnValue([COMPOUNDER_ADDRESS])
+    mocks.getMorphoVaultsFromStrategies.mockResolvedValue({
+      [COMPOUNDER_ADDRESS]: MORPHO_VAULT_ADDRESS,
+    })
+    mocks.getVaultAprEstimates.mockRejectedValue(new Error('Morpho unavailable'))
+    mocks.getMorphoOpportunities.mockResolvedValue([
+      makeOpportunity({
+        address: MORPHO_VAULT_ADDRESS,
+        aprPercent: 2,
+        campaignId: 'underlying-reward',
+      }),
+    ])
+
+    const calculator = new MorphoUnderlyingAprCalculator()
+    const results = await calculator.calculateVaultAPRs([vault])
+    const result = results[VAULT_ADDRESS][0]
+
+    expect(result.morphoEstimateSource).toBe(
+      MORPHO_ESTIMATE_SOURCE.MERKL_UNDERLYING,
+    )
+    expect(result.morphoBaseAPR).toBe(0.01)
+    expect(result.morphoRewardsAPR).toBe(0.02)
+    expect(result.replacementAPR).toBeCloseTo(0.03)
+    expect(result.usedMorphoApi).toBe(false)
+    expect(consoleError).toHaveBeenCalledWith(
+      'Error resolving Morpho vault APR estimates:',
+      expect.any(Error),
+    )
+
+    consoleError.mockRestore()
+  })
+
+  it('prefers underlying-address rewards over strategy-address rewards', async () => {
+    const vault = makeVault()
+    mocks.getMorphoCompounderStrategies.mockReturnValue([COMPOUNDER_ADDRESS])
+    mocks.getMorphoVaultsFromStrategies.mockResolvedValue({
+      [COMPOUNDER_ADDRESS]: MORPHO_VAULT_ADDRESS,
+    })
+    mocks.getVaultAprEstimates.mockResolvedValue({})
+    mocks.getMorphoOpportunities.mockResolvedValue([
+      makeOpportunity({
+        address: MORPHO_VAULT_ADDRESS,
+        aprPercent: 2,
+        campaignId: 'underlying-reward',
+      }),
+      makeOpportunity({
+        address: COMPOUNDER_ADDRESS,
+        aprPercent: 9,
+        campaignId: 'strategy-reward',
+      }),
+    ])
+
+    const calculator = new MorphoUnderlyingAprCalculator()
+    const results = await calculator.calculateVaultAPRs([vault])
+    const result = results[VAULT_ADDRESS][0]
+
+    expect(result.morphoEstimateSource).toBe(
+      MORPHO_ESTIMATE_SOURCE.MERKL_UNDERLYING,
+    )
+    expect(result.morphoRewardsAPR).toBe(0.02)
+    expect(result.replacementAPR).toBeCloseTo(0.03)
+  })
+
+  it('uses strategy-address Merkl rewards when the underlying mapping is unavailable', async () => {
+    const vault = makeVault()
+    mocks.getMorphoCompounderStrategies.mockReturnValue([COMPOUNDER_ADDRESS])
+    mocks.getMorphoVaultsFromStrategies.mockResolvedValue({})
+    mocks.getVaultAprEstimates.mockResolvedValue({})
+    mocks.getMorphoOpportunities.mockResolvedValue([
+      makeOpportunity({
+        address: COMPOUNDER_ADDRESS,
+        aprPercent: 1.5,
+        campaignId: 'strategy-reward',
+      }),
+    ])
+
+    const calculator = new MorphoUnderlyingAprCalculator()
+    const results = await calculator.calculateVaultAPRs([vault])
+    const result = results[VAULT_ADDRESS][0]
+
+    expect(result.morphoVaultAddress).toBeNull()
+    expect(result.morphoEstimateSource).toBe(
+      MORPHO_ESTIMATE_SOURCE.MERKL_STRATEGY,
+    )
+    expect(result.morphoRewardsAPR).toBe(0.015)
+    expect(result.replacementAPR).toBeCloseTo(0.025)
+  })
+
+  it('does not treat KAT-only strategy opportunities as Morpho estimate coverage', async () => {
+    const vault = makeVault()
+    mocks.getMorphoCompounderStrategies.mockReturnValue([COMPOUNDER_ADDRESS])
+    mocks.getMorphoVaultsFromStrategies.mockResolvedValue({
+      [COMPOUNDER_ADDRESS]: MORPHO_VAULT_ADDRESS,
+    })
+    mocks.getVaultAprEstimates.mockResolvedValue({})
+    mocks.getMorphoOpportunities.mockResolvedValue([
+      makeOpportunity({
+        address: COMPOUNDER_ADDRESS,
+        aprPercent: 12,
+        campaignId: 'kat-only-reward',
+        rewardTokenAddress: KAT_REWARD_TOKEN,
+      }),
+    ])
+
+    const calculator = new MorphoUnderlyingAprCalculator()
+    const results = await calculator.calculateVaultAPRs([vault])
+    const result = results[VAULT_ADDRESS][0]
+
+    expect(result.morphoEstimateSource).toBe(
+      MORPHO_ESTIMATE_SOURCE.KONG_ORACLE,
+    )
+    expect(result.morphoRewardsAPR).toBe(0)
+    expect(result.replacementAPR).toBe(0.01)
+  })
+
+  it('excludes blacklisted campaigns from Merkl estimates', async () => {
+    const vault = makeVault()
+    mocks.getMorphoCompounderStrategies.mockReturnValue([COMPOUNDER_ADDRESS])
+    mocks.getMorphoVaultsFromStrategies.mockResolvedValue({
+      [COMPOUNDER_ADDRESS]: MORPHO_VAULT_ADDRESS,
+    })
+    mocks.getVaultAprEstimates.mockResolvedValue({})
+    mocks.getMorphoOpportunities.mockResolvedValue([
+      makeOpportunity({
+        address: MORPHO_VAULT_ADDRESS,
+        aprPercent: 99,
+        campaignId: BLACKLISTED_CAMPAIGN_ID,
+      }),
+    ])
+
+    const calculator = new MorphoUnderlyingAprCalculator()
+    const results = await calculator.calculateVaultAPRs([vault])
+    const result = results[VAULT_ADDRESS][0]
+
+    expect(result.morphoEstimateSource).toBe(
+      MORPHO_ESTIMATE_SOURCE.KONG_ORACLE,
+    )
+    expect(result.morphoRewardsAPR).toBe(0)
+  })
+
+  it('prefers MORPHOVAULT data over ERC20LOGPROCESSOR data at one address', async () => {
+    const vault = makeVault()
+    mocks.getMorphoCompounderStrategies.mockReturnValue([COMPOUNDER_ADDRESS])
+    mocks.getMorphoVaultsFromStrategies.mockResolvedValue({
+      [COMPOUNDER_ADDRESS]: MORPHO_VAULT_ADDRESS,
+    })
+    mocks.getVaultAprEstimates.mockResolvedValue({})
+    mocks.getMorphoOpportunities.mockResolvedValue([
+      makeOpportunity({
+        address: MORPHO_VAULT_ADDRESS,
+        aprPercent: 2,
+        campaignId: 'morpho-vault-reward',
+        type: 'MORPHOVAULT',
+      }),
+      makeOpportunity({
+        address: MORPHO_VAULT_ADDRESS,
+        aprPercent: 7,
+        campaignId: 'log-processor-reward',
+      }),
+    ])
+
+    const calculator = new MorphoUnderlyingAprCalculator()
+    const results = await calculator.calculateVaultAPRs([vault])
+    const result = results[VAULT_ADDRESS][0]
+
+    expect(result.morphoRewardsAPR).toBe(0.02)
+    expect(result.replacementAPR).toBeCloseTo(0.03)
+  })
+
+  it('returns no estimate only when every rung is unavailable', async () => {
+    const vault = makeVault()
+    vault.strategies[0].netAPR = null
+    mocks.getMorphoCompounderStrategies.mockReturnValue([COMPOUNDER_ADDRESS])
+    mocks.getMorphoVaultsFromStrategies.mockResolvedValue({
+      [COMPOUNDER_ADDRESS]: MORPHO_VAULT_ADDRESS,
+    })
+    mocks.getVaultAprEstimates.mockResolvedValue({})
+
+    const calculator = new MorphoUnderlyingAprCalculator()
+    const results = await calculator.calculateVaultAPRs([vault])
+
+    expect(results[VAULT_ADDRESS][0]).toMatchObject({
+      replacementAPR: null,
+      estimatedAPY: null,
+      morphoEstimateSource: null,
+    })
   })
 })

--- a/src/app/services/aprCalcs/morphoUnderlyingAprCalculator.ts
+++ b/src/app/services/aprCalcs/morphoUnderlyingAprCalculator.ts
@@ -1,8 +1,21 @@
 import _ from 'lodash'
-import type { YearnVault } from '../../types'
+import {
+  MORPHO_ESTIMATE_SOURCE,
+  type MerklOpportunity,
+  type MorphoEstimateSource,
+  type YearnVault,
+} from '../../types'
 import { ContractReaderService } from '../contractReader'
+import { isKatanaRewardTokenAddress } from '../katanaRewardTokens'
+import { isExcludedCampaignId } from '../externalApis/merklBlacklist'
+import { MerklApiService } from '../externalApis/merklApi'
 import { MorphoApiService, type MorphoVaultAprEstimate } from '../externalApis/morphoApi'
 import { YearnApiService } from '../externalApis/yearnApi'
+
+const MERKL_ESTIMATE_OPPORTUNITY_TYPES = [
+  'MORPHOVAULT',
+  'ERC20LOGPROCESSOR',
+] as const
 
 export interface MorphoUnderlyingAprResult {
   strategyAddress: string
@@ -13,21 +26,25 @@ export interface MorphoUnderlyingAprResult {
   replacementAPR: number | null
   estimatedAPY: number | null
   usedMorphoApi: boolean
+  morphoEstimateSource: MorphoEstimateSource | null
 }
 
 export class MorphoUnderlyingAprCalculator {
   private yearnApi: YearnApiService
   private contractReader: ContractReaderService
+  private merklApi: MerklApiService
   private morphoApi: MorphoApiService
 
   constructor() {
     this.yearnApi = new YearnApiService()
     this.contractReader = new ContractReaderService()
+    this.merklApi = new MerklApiService()
     this.morphoApi = new MorphoApiService()
   }
 
   async calculateVaultAPRs(
     vaults: YearnVault[],
+    suppliedMorphoOpportunities?: MerklOpportunity[],
   ): Promise<Record<string, MorphoUnderlyingAprResult[]>> {
     const vaultStrategyPairs = vaults
       .map((vault) => ({
@@ -54,6 +71,9 @@ export class MorphoUnderlyingAprCalculator {
     const morphoVaultEstimates = await this.getMorphoVaultEstimates(
       morphoVaultAddresses,
     )
+    const morphoOpportunities =
+      suppliedMorphoOpportunities ??
+      (await this.merklApi.getMorphoOpportunities())
 
     const resultEntries = vaultStrategyPairs
       .map(({ vault, strategyAddresses }) => {
@@ -79,10 +99,16 @@ export class MorphoUnderlyingAprCalculator {
             const estimate = morphoVaultAddress
               ? morphoVaultEstimates[morphoVaultAddress.toLowerCase()]
               : undefined
+            const oracleAPR = this.toFiniteNumberOrNull(strategy.netAPR)
 
             const aprEstimate = estimate
               ? this.buildMorphoAprEstimate(estimate)
-              : this.buildUnavailableAprEstimate()
+              : this.buildFallbackAprEstimate(
+                  strategyAddress,
+                  morphoVaultAddress,
+                  oracleAPR,
+                  morphoOpportunities,
+                )
 
             return {
               strategyAddress,
@@ -128,7 +154,12 @@ export class MorphoUnderlyingAprCalculator {
       return {}
     }
 
-    return this.morphoApi.getVaultAprEstimates(morphoVaultAddresses)
+    try {
+      return await this.morphoApi.getVaultAprEstimates(morphoVaultAddresses)
+    } catch (error) {
+      console.error('Error resolving Morpho vault APR estimates:', error)
+      return {}
+    }
   }
 
   private buildMorphoAprEstimate(estimate: MorphoVaultAprEstimate): Omit<
@@ -145,20 +176,151 @@ export class MorphoUnderlyingAprCalculator {
       morphoRewardsAPR,
       replacementAPR,
       estimatedAPY: this.convertAprToWeeklyApy(replacementAPR),
+      morphoEstimateSource: MORPHO_ESTIMATE_SOURCE.MORPHO_API,
     }
   }
 
-  private buildUnavailableAprEstimate(): Omit<
+  private buildFallbackAprEstimate(
+    strategyAddress: string,
+    morphoVaultAddress: string | null,
+    oracleAPR: number | null,
+    morphoOpportunities: MerklOpportunity[],
+  ): Omit<
     MorphoUnderlyingAprResult,
     'strategyAddress' | 'morphoVaultAddress' | 'usedMorphoApi'
   > {
+    if (morphoVaultAddress) {
+      const underlyingRewardsAPR = this.getMerklRewardsAPR(
+        morphoVaultAddress,
+        morphoOpportunities,
+      )
+      if (underlyingRewardsAPR !== null) {
+        return this.buildMerklAprEstimate(
+          underlyingRewardsAPR,
+          oracleAPR,
+          MORPHO_ESTIMATE_SOURCE.MERKL_UNDERLYING,
+        )
+      }
+    }
+
+    const strategyRewardsAPR = this.getMerklRewardsAPR(
+      strategyAddress,
+      morphoOpportunities,
+    )
+    if (strategyRewardsAPR !== null) {
+      return this.buildMerklAprEstimate(
+        strategyRewardsAPR,
+        oracleAPR,
+        MORPHO_ESTIMATE_SOURCE.MERKL_STRATEGY,
+      )
+    }
+
+    if (oracleAPR !== null) {
+      return {
+        morphoBaseAPR: oracleAPR,
+        morphoBaseAPY: this.convertAprToWeeklyApy(oracleAPR),
+        morphoRewardsAPR: 0,
+        replacementAPR: oracleAPR,
+        estimatedAPY: this.convertAprToWeeklyApy(oracleAPR),
+        morphoEstimateSource: MORPHO_ESTIMATE_SOURCE.KONG_ORACLE,
+      }
+    }
+
     return {
       morphoBaseAPR: 0,
       morphoBaseAPY: 0,
       morphoRewardsAPR: 0,
       replacementAPR: null,
       estimatedAPY: null,
+      morphoEstimateSource: null,
     }
+  }
+
+  private buildMerklAprEstimate(
+    morphoRewardsAPR: number,
+    oracleAPR: number | null,
+    morphoEstimateSource: MorphoEstimateSource,
+  ): Omit<
+    MorphoUnderlyingAprResult,
+    'strategyAddress' | 'morphoVaultAddress' | 'usedMorphoApi'
+  > {
+    const morphoBaseAPR = oracleAPR ?? 0
+    const replacementAPR = morphoBaseAPR + morphoRewardsAPR
+
+    return {
+      morphoBaseAPR,
+      morphoBaseAPY: this.convertAprToWeeklyApy(morphoBaseAPR),
+      morphoRewardsAPR,
+      replacementAPR,
+      estimatedAPY: this.convertAprToWeeklyApy(replacementAPR),
+      morphoEstimateSource,
+    }
+  }
+
+  private getMerklRewardsAPR(
+    address: string,
+    opportunities: MerklOpportunity[],
+  ): number | null {
+    const normalizedAddress = address.toLowerCase()
+    const matchingOpportunities = opportunities.filter(
+      (opportunity) =>
+        opportunity.status.toUpperCase() === 'LIVE' &&
+        opportunity.identifier.toLowerCase() === normalizedAddress,
+    )
+
+    for (const opportunityType of MERKL_ESTIMATE_OPPORTUNITY_TYPES) {
+      const campaignAprById = new Map<string, number>()
+
+      for (const opportunity of matchingOpportunities) {
+        if (opportunity.type?.toUpperCase() !== opportunityType) {
+          continue
+        }
+
+        const breakdowns = new Map(
+          (opportunity.aprRecord?.breakdowns || []).flatMap((breakdown) => {
+            const value = this.toFiniteNumberOrNull(breakdown.value)
+            return breakdown.identifier && value !== null
+              ? [[breakdown.identifier.toLowerCase(), value] as const]
+              : []
+          }),
+        )
+
+        for (const campaign of opportunity.campaigns || []) {
+          if (
+            !campaign.campaignId ||
+            isExcludedCampaignId(campaign.campaignId) ||
+            isKatanaRewardTokenAddress(campaign.rewardToken.address)
+          ) {
+            continue
+          }
+
+          const campaignId = campaign.campaignId.toLowerCase()
+          const aprPercent = breakdowns.get(campaignId)
+          if (aprPercent !== undefined) {
+            campaignAprById.set(campaignId, aprPercent)
+          }
+        }
+      }
+
+      if (campaignAprById.size > 0) {
+        const totalAprPercent = Array.from(campaignAprById.values()).reduce(
+          (sum, apr) => sum + apr,
+          0,
+        )
+        return totalAprPercent / 100
+      }
+    }
+
+    return null
+  }
+
+  private toFiniteNumberOrNull(value: unknown): number | null {
+    if (value === null || value === undefined || value === '') {
+      return null
+    }
+
+    const parsed = typeof value === 'number' ? value : Number(value)
+    return Number.isFinite(parsed) ? parsed : null
   }
 
   private convertApyToWeeklyApr(apy: number): number {

--- a/src/app/services/dataCache.test.ts
+++ b/src/app/services/dataCache.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { YearnVault } from '../types'
+import { MORPHO_ESTIMATE_SOURCE, type YearnVault } from '../types'
 
 const mocks = vi.hoisted(() => ({
   mockGetVaults: vi.fn(),
+  mockGetMorphoOpportunities: vi.fn(),
   mockCalculateYearnVaultAPRs: vi.fn(),
   mockCalculateMorphoVaultAPRs: vi.fn(),
   mockCalculateMorphoUnderlyingVaultAPRs: vi.fn(),
@@ -13,6 +14,12 @@ const mocks = vi.hoisted(() => ({
 vi.mock('./externalApis/yearnApi', () => ({
   YearnApiService: vi.fn().mockImplementation(() => ({
     getVaults: mocks.mockGetVaults,
+  })),
+}))
+
+vi.mock('./externalApis/merklApi', () => ({
+  MerklApiService: vi.fn().mockImplementation(() => ({
+    getMorphoOpportunities: mocks.mockGetMorphoOpportunities,
   })),
 }))
 
@@ -63,12 +70,14 @@ const makeVault = (overrides: Partial<YearnVault> = {}): YearnVault => ({
 describe('DataCacheService.generateVaultAPRData', () => {
   beforeEach(() => {
     mocks.mockGetVaults.mockReset()
+    mocks.mockGetMorphoOpportunities.mockReset()
     mocks.mockCalculateYearnVaultAPRs.mockReset()
     mocks.mockCalculateMorphoVaultAPRs.mockReset()
     mocks.mockCalculateMorphoUnderlyingVaultAPRs.mockReset()
     mocks.mockCalculateSushiVaultAPRs.mockReset()
     mocks.logVaultAprDebug.mockReset()
     mocks.mockCalculateYearnVaultAPRs.mockResolvedValue({})
+    mocks.mockGetMorphoOpportunities.mockResolvedValue([])
     mocks.mockCalculateMorphoVaultAPRs.mockResolvedValue({})
     mocks.mockCalculateMorphoUnderlyingVaultAPRs.mockResolvedValue({})
     mocks.mockCalculateSushiVaultAPRs.mockResolvedValue({})
@@ -84,6 +93,15 @@ describe('DataCacheService.generateVaultAPRData', () => {
     const service = new DataCacheService()
     const data = await service.generateVaultAPRData()
 
+    expect(mocks.mockGetMorphoOpportunities).toHaveBeenCalledOnce()
+    expect(mocks.mockCalculateMorphoVaultAPRs).toHaveBeenCalledWith(
+      [vault],
+      [],
+    )
+    expect(mocks.mockCalculateMorphoUnderlyingVaultAPRs).toHaveBeenCalledWith(
+      [vault],
+      [],
+    )
     expect(data[vault.address]).toEqual({
       name: vault.name,
       apr: 0,
@@ -395,6 +413,7 @@ describe('DataCacheService.generateVaultAPRData', () => {
           replacementAPR: 0.10,
           estimatedAPY: (1 + 0.10 / 52) ** 52 - 1,
           usedMorphoApi: true,
+          morphoEstimateSource: MORPHO_ESTIMATE_SOURCE.MORPHO_API,
         },
         {
           strategyAddress: idleStrategyAddress,
@@ -406,6 +425,7 @@ describe('DataCacheService.generateVaultAPRData', () => {
           replacementAPR: 0.50,
           estimatedAPY: (1 + 0.50 / 52) ** 52 - 1,
           usedMorphoApi: true,
+          morphoEstimateSource: MORPHO_ESTIMATE_SOURCE.MORPHO_API,
         },
       ],
     })
@@ -432,6 +452,7 @@ describe('DataCacheService.generateVaultAPRData', () => {
     expect(data[vault.address].strategies[0].morphoUnderlyingAPR).toEqual({
       morphoVaultAddress: '0x00000000000000000000000000000000000000a1',
       usedMorphoApi: true,
+      morphoEstimateSource: MORPHO_ESTIMATE_SOURCE.MORPHO_API,
       morphoBaseAPR: 0.08,
       morphoBaseAPY: 0.0832,
       morphoRewardsAPR: 0.02,
@@ -442,6 +463,7 @@ describe('DataCacheService.generateVaultAPRData', () => {
     expect(data[vault.address].strategies[2].morphoUnderlyingAPR).toEqual({
       morphoVaultAddress: '0x00000000000000000000000000000000000000a2',
       usedMorphoApi: true,
+      morphoEstimateSource: MORPHO_ESTIMATE_SOURCE.MORPHO_API,
       morphoBaseAPR: 0.20,
       morphoBaseAPY: 0.22,
       morphoRewardsAPR: 0.30,
@@ -485,12 +507,13 @@ describe('DataCacheService.generateVaultAPRData', () => {
           strategyAddress: morphoStrategyAddress,
           morphoVaultAddress:
             '0x00000000000000000000000000000000000000a2',
-          morphoBaseAPR: 0,
-          morphoBaseAPY: 0,
+          morphoBaseAPR: 0.03,
+          morphoBaseAPY: (1 + 0.03 / 52) ** 52 - 1,
           morphoRewardsAPR: 0,
-          replacementAPR: null,
-          estimatedAPY: null,
+          replacementAPR: 0.03,
+          estimatedAPY: (1 + 0.03 / 52) ** 52 - 1,
           usedMorphoApi: false,
+          morphoEstimateSource: MORPHO_ESTIMATE_SOURCE.KONG_ORACLE,
         },
       ],
     })
@@ -503,12 +526,106 @@ describe('DataCacheService.generateVaultAPRData', () => {
     expect(data[vault.address].strategies[0].netAPR).toBe(0.03)
     expect(data[vault.address].strategies[0].morphoUnderlyingAPR).toMatchObject({
       usedMorphoApi: false,
-      estimatedAPR: null,
-      estimatedAPY: null,
+      morphoEstimateSource: MORPHO_ESTIMATE_SOURCE.KONG_ORACLE,
+      estimatedAPR: 0.03,
+      estimatedAPY: (1 + 0.03 / 52) ** 52 - 1,
     })
     expect(
       data[vault.address].apr?.forwardAPR?.morphoUnderlying?.coveredDebtRatio,
     ).toBe(0)
+  })
+
+  it('counts Merkl estimates as coverage while keeping zero oracle fallbacks complete', async () => {
+    const merklStrategyAddress =
+      '0x00000000000000000000000000000000000000f6'
+    const oracleStrategyAddress =
+      '0x00000000000000000000000000000000000000f7'
+    const vault = makeVault({
+      tvl: {
+        totalAssets: '100',
+        tvl: 100,
+        price: 1,
+      },
+      strategies: [
+        {
+          address: merklStrategyAddress,
+          name: 'Morpho Merkl Compounder',
+          status: 'active',
+          netAPR: 0.04,
+          details: {
+            totalDebt: '50',
+            totalGain: '0',
+            totalLoss: '0',
+            lastReport: 0,
+            debtRatio: 5000,
+          },
+        },
+        {
+          address: oracleStrategyAddress,
+          name: 'Morpho Oracle Compounder',
+          status: 'active',
+          netAPR: 0,
+          details: {
+            totalDebt: '50',
+            totalGain: '0',
+            totalLoss: '0',
+            lastReport: 0,
+            debtRatio: 5000,
+          },
+        },
+      ],
+    })
+    mocks.mockGetVaults.mockResolvedValue([vault])
+    mocks.mockCalculateMorphoUnderlyingVaultAPRs.mockResolvedValue({
+      [vault.address]: [
+        {
+          strategyAddress: merklStrategyAddress,
+          morphoVaultAddress:
+            '0x00000000000000000000000000000000000000b1',
+          morphoBaseAPR: 0.04,
+          morphoBaseAPY: (1 + 0.04 / 52) ** 52 - 1,
+          morphoRewardsAPR: 0.02,
+          replacementAPR: 0.06,
+          estimatedAPY: (1 + 0.06 / 52) ** 52 - 1,
+          usedMorphoApi: false,
+          morphoEstimateSource:
+            MORPHO_ESTIMATE_SOURCE.MERKL_UNDERLYING,
+        },
+        {
+          strategyAddress: oracleStrategyAddress,
+          morphoVaultAddress:
+            '0x00000000000000000000000000000000000000b2',
+          morphoBaseAPR: 0,
+          morphoBaseAPY: 0,
+          morphoRewardsAPR: 0,
+          replacementAPR: 0,
+          estimatedAPY: 0,
+          usedMorphoApi: false,
+          morphoEstimateSource: MORPHO_ESTIMATE_SOURCE.KONG_ORACLE,
+        },
+      ],
+    })
+
+    const service = new DataCacheService()
+    const data = await service.generateVaultAPRData()
+
+    expect(data[vault.address].apr?.forwardAPR?.netAPR).toBeCloseTo(0.03)
+    expect(data[vault.address].apr?.forwardAPR?.morphoUnderlying).toEqual({
+      baseAPR: 0.02,
+      baseAPY: ((1 + 0.04 / 52) ** 52 - 1) * 0.5,
+      rewardsAPR: 0.01,
+      estimatedAPR: 0.03,
+      estimatedAPY: (1 + 0.03 / 52) ** 52 - 1,
+      coveredDebtRatio: 0.5,
+    })
+    expect(data[vault.address].strategies[0].morphoUnderlyingAPR).toMatchObject({
+      morphoEstimateSource: MORPHO_ESTIMATE_SOURCE.MERKL_UNDERLYING,
+      estimatedAPR: 0.06,
+    })
+    expect(data[vault.address].strategies[1].morphoUnderlyingAPR).toMatchObject({
+      morphoEstimateSource: MORPHO_ESTIMATE_SOURCE.KONG_ORACLE,
+      estimatedAPR: 0,
+    })
   })
 
   it('reports full estimated debt coverage for a zero-yield live Morpho estimate', async () => {
@@ -548,6 +665,7 @@ describe('DataCacheService.generateVaultAPRData', () => {
           replacementAPR: 0,
           estimatedAPY: 0,
           usedMorphoApi: true,
+          morphoEstimateSource: MORPHO_ESTIMATE_SOURCE.MORPHO_API,
         },
       ],
     })

--- a/src/app/services/dataCache.ts
+++ b/src/app/services/dataCache.ts
@@ -1,7 +1,9 @@
 import _ from 'lodash'
 import { config } from '../config/index'
 import type { YearnStrategy, YearnVault, YearnVaultAPY } from '../types/index'
+import { MORPHO_ESTIMATE_SOURCE } from '../types/index'
 import { YearnApiService } from './externalApis/yearnApi'
+import { MerklApiService } from './externalApis/merklApi'
 import { MorphoAprCalculator } from './aprCalcs/morphoAprCalculator'
 import {
   MorphoUnderlyingAprCalculator,
@@ -40,6 +42,7 @@ const KATANA_ACCOUNTANT_DEFAULT_MAX_FEE = 0.5
 
 export class DataCacheService {
   private yearnApi: YearnApiService
+  private merklApi: MerklApiService
   private yearnAprCalculator: YearnAprCalculator
   private morphoAprCalculator: MorphoAprCalculator
   private morphoUnderlyingAprCalculator: MorphoUnderlyingAprCalculator
@@ -47,6 +50,7 @@ export class DataCacheService {
 
   constructor() {
     this.yearnApi = new YearnApiService()
+    this.merklApi = new MerklApiService()
     this.yearnAprCalculator = new YearnAprCalculator()
     this.morphoAprCalculator = new MorphoAprCalculator()
     this.morphoUnderlyingAprCalculator = new MorphoUnderlyingAprCalculator()
@@ -66,6 +70,10 @@ export class DataCacheService {
       )
     }
 
+    // Share the existing bulk Morpho opportunity fetch between reward and
+    // forward-estimate calculators. Never fetch Merkl once per strategy.
+    const morphoOpportunitiesPromise = this.merklApi.getMorphoOpportunities()
+
     // Get APR data from each calculator
     const [
       yearnAPRs,
@@ -74,8 +82,15 @@ export class DataCacheService {
       sushiAPRs,
     ] = await Promise.all([
       this.yearnAprCalculator.calculateVaultAPRs(vaults),
-      this.morphoAprCalculator.calculateVaultAPRs(vaults),
-      this.morphoUnderlyingAprCalculator.calculateVaultAPRs(vaults),
+      morphoOpportunitiesPromise.then((opportunities) =>
+        this.morphoAprCalculator.calculateVaultAPRs(vaults, opportunities),
+      ),
+      morphoOpportunitiesPromise.then((opportunities) =>
+        this.morphoUnderlyingAprCalculator.calculateVaultAPRs(
+          vaults,
+          opportunities,
+        ),
+      ),
       this.sushiAprCalculator.calculateVaultAPRs(vaults),
     ])
 
@@ -200,7 +215,7 @@ export class DataCacheService {
           : strategy.strategyRewardsAPR ?? strategyRewards.rawApr
         : strategy.strategyRewardsAPR ?? null
       const liveStrategyNetAPR =
-        morphoUnderlying && this.hasLiveMorphoReplacement(morphoUnderlying)
+        morphoUnderlying && this.hasMorphoReplacement(morphoUnderlying)
           ? morphoUnderlying.replacementAPR
           : this.getKongOracleAPR(strategy)
 
@@ -212,6 +227,8 @@ export class DataCacheService {
               morphoUnderlyingAPR: {
                 morphoVaultAddress: morphoUnderlying.morphoVaultAddress,
                 usedMorphoApi: morphoUnderlying.usedMorphoApi,
+                morphoEstimateSource:
+                  morphoUnderlying.morphoEstimateSource,
                 morphoBaseAPR: morphoUnderlying.morphoBaseAPR,
                 morphoBaseAPY: morphoUnderlying.morphoBaseAPY,
                 morphoRewardsAPR: morphoUnderlying.morphoRewardsAPR,
@@ -301,11 +318,11 @@ export class DataCacheService {
       return vault.apr?.forwardAPR
     }
 
-    const liveMorphoResults = morphoUnderlyingResults.filter(
-      this.hasLiveMorphoReplacement,
+    const resolvedMorphoResults = morphoUnderlyingResults.filter(
+      this.hasMorphoReplacement,
     )
     const morphoReplacementByStrategy = new Map(
-      liveMorphoResults.map((result) => [
+      resolvedMorphoResults.map((result) => [
         result.strategyAddress.toLowerCase(),
         result.replacementAPR,
       ]),
@@ -355,7 +372,11 @@ export class DataCacheService {
       },
       morphoUnderlying: this.buildVaultMorphoUnderlyingAPR(
         vault,
-        liveMorphoResults,
+        resolvedMorphoResults.filter(
+          (result) =>
+            result.morphoEstimateSource !==
+            MORPHO_ESTIMATE_SOURCE.KONG_ORACLE,
+        ),
       ),
     }
   }
@@ -491,13 +512,12 @@ export class DataCacheService {
     }
   }
 
-  private hasLiveMorphoReplacement(
+  private hasMorphoReplacement(
     result: MorphoUnderlyingAprResult,
   ): result is MorphoUnderlyingAprResult & {
     replacementAPR: number
   } {
     return (
-      result.usedMorphoApi &&
       typeof result.replacementAPR === 'number' &&
       Number.isFinite(result.replacementAPR)
     )

--- a/src/app/types/yearn.ts
+++ b/src/app/types/yearn.ts
@@ -14,9 +14,20 @@ export interface YearnRewardToken {
   assumedFDV?: number
 }
 
+export const MORPHO_ESTIMATE_SOURCE = {
+  MORPHO_API: 0,
+  MERKL_UNDERLYING: 1,
+  MERKL_STRATEGY: 2,
+  KONG_ORACLE: 3,
+} as const
+
+export type MorphoEstimateSource =
+  (typeof MORPHO_ESTIMATE_SOURCE)[keyof typeof MORPHO_ESTIMATE_SOURCE]
+
 export interface MorphoUnderlyingAPR {
   morphoVaultAddress: string | null
   usedMorphoApi: boolean
+  morphoEstimateSource: MorphoEstimateSource | null
   morphoBaseAPR: number
   morphoBaseAPY: number
   morphoRewardsAPR: number


### PR DESCRIPTION
### Summary
Morpho API failures can leave strategy estimates unavailable. This adds a fallback ladder that uses eligible Merkl rewards before falling back to the existing Kong oracle value.

This PR is stacked on #65. Review and merge #65 first.

### How to review
Start with `morphoUnderlyingAprCalculator.ts`. Check the source order: Morpho API, Merkl at the underlying vault address, Merkl at the strategy address, then Kong oracle.

Confirm that Merkl matching uses exact addresses, ignores KAT and blacklisted campaigns, and keeps non-KAT rewards. Then review `dataCache.ts` and the webhook output for estimate-source and debt-coverage handling. The landing and quick-APY pages are unchanged and can be skipped.

### Test plan
- [x] Manual: Started the production build and confirmed `/api/health` and `/api/vaults` return successfully.
- [x] Manual: Simulated a Morpho API outage and confirmed vault data still returns with Merkl or Kong fallback sources.
- [x] Automated: `bun run test:run` (80 tests passed)
- [x] Automated: `bun run lint`
- [x] Automated: `bun run build`
- [x] Automated: `git diff --check`

### Risk / impact
This changes APR estimates and their source metadata, but it does not move funds or submit transactions. Incorrect campaign filtering could overstate rewards, so the implementation excludes KAT and blacklisted campaigns and requires matching APR breakdowns.

The service reuses one bulk Merkl request for both reward calculations to avoid increasing request volume. Reverting this PR restores the Morpho API and Kong-only behavior.
